### PR TITLE
Added "ß" dialect to processing py

### DIFF
--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -402,7 +402,7 @@ def iupac_extended_to_condensed(iupac_extended):
     # Move the α or β after the next opening parenthesis
     return f"{match.group('after')}{match.group('alpha_beta')}"
   # The regular expression looks for α-D- or β-D- followed by any characters until an open parenthesis
-  pattern = re.compile(r"(?P<alpha_beta>[αβab\?])-[DL]-(?P<after>[^\)]*\()")
+  pattern = re.compile(r"(?P<alpha_beta>[αβßab\?])-[DL]-(?P<after>[^\)]*\()")
   # Substitute the pattern in the string with our replace_pattern function
   adjusted_string = pattern.sub(replace_pattern, iupac_extended)
   adjusted_string = re.sub(r"-\(", "(", adjusted_string)
@@ -826,7 +826,7 @@ def canonicalize_iupac(glycan):
   replace_dic = {'Nac': 'NAc', 'AC': 'Ac', 'Nc': 'NAc', 'NeuAc': 'Neu5Ac', 'NeuNAc': 'Neu5Ac', 'NeuGc': 'Neu5Gc',
                  '\u03B1': 'a', '\u03B2': 'b', 'N(Gc)': 'NGc', 'GL': 'Gl', 'GaN': 'GalN', '(9Ac)': '9Ac',
                  'KDN': 'Kdn', 'OSO3': 'S', '-O-Su-': 'S', '(S)': 'S', 'H2PO3': 'P', '(P)': 'P',
-                 '–': '-', ' ': '', ',': '-', 'α': 'a', 'β': 'b', '.': '', '((': '(', '))': ')', '→': '-',
+                 '–': '-', ' ': '', ',': '-', 'α': 'a', 'β': 'b', 'ß': 'b', '.': '', '((': '(', '))': ')', '{': '(', '}': ')', '→': '-',
                  'Glcp': 'Glc', 'Galp': 'Gal', 'Manp': 'Man', 'Fucp': 'Fuc', 'Neup': 'Neu', 'a?': 'a1',
                  '5Ac4Ac': '4Ac5Ac'}
   glycan = multireplace(glycan, replace_dic)

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -826,7 +826,7 @@ def canonicalize_iupac(glycan):
   replace_dic = {'Nac': 'NAc', 'AC': 'Ac', 'Nc': 'NAc', 'NeuAc': 'Neu5Ac', 'NeuNAc': 'Neu5Ac', 'NeuGc': 'Neu5Gc',
                  '\u03B1': 'a', '\u03B2': 'b', 'N(Gc)': 'NGc', 'GL': 'Gl', 'GaN': 'GalN', '(9Ac)': '9Ac',
                  'KDN': 'Kdn', 'OSO3': 'S', '-O-Su-': 'S', '(S)': 'S', 'H2PO3': 'P', '(P)': 'P',
-                 '–': '-', ' ': '', ',': '-', 'α': 'a', 'β': 'b', 'ß': 'b', '.': '', '((': '(', '))': ')', '{': '(', '}': ')', '→': '-',
+                 '–': '-', ' ': '', ',': '-', 'α': 'a', 'β': 'b', 'ß': 'b', '.': '', '((': '(', '))': ')', '→': '-',
                  'Glcp': 'Glc', 'Galp': 'Gal', 'Manp': 'Man', 'Fucp': 'Fuc', 'Neup': 'Neu', 'a?': 'a1',
                  '5Ac4Ac': '4Ac5Ac'}
   glycan = multireplace(glycan, replace_dic)


### PR DESCRIPTION
ß is sometimes written instead of β or b, added this to the regular expression for iupac_extended replace_pattern and to the replace_dic for canonicalize_iupac.

{ and } is sometimes written instead of ( or  ) for linkages so I added that to replace_dic as well. { or } might also show up instead of (, [, ], ) for branching, but I'm not sure how to account for that.

nbdev prepare warns about cells containing both import and other code. It did this before my proposed changes. I assume this is just improper style according to nbdev and does not impact function. The error tells me to refer to the FAQ, alas I can't find any information about this on the nbdev website including the FAQ. I'm not used to nbdev. Nbdev_prepare makes plenty of changes to both a freshly pulled dev branch as well as after my proposed changes, but these edits by nbdev are not part of this pull request.

Copy paste from fresh dev branch pull with nbdev_install_hooks and nbdev_prepare being run before git status:

```
git status
On branch dev
Your branch is up to date with 'origin/dev'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   00_core.ipynb
        modified:   01_glycan_data.ipynb
        modified:   02_ml.ipynb
        modified:   03_motif.ipynb
        modified:   04_network.ipynb
        modified:   05_examples.ipynb
        deleted:    _proc/.gitignore
        deleted:    _proc/.quarto/idx/00_core.ipynb.json
        deleted:    _proc/.quarto/xref/INDEX
        modified:   _proc/00_core.ipynb
        modified:   _proc/01_glycan_data.ipynb
        modified:   _proc/02_ml.ipynb
        deleted:    _proc/03_motif.ipynb
        deleted:    _proc/04_network.ipynb
        modified:   _proc/05_examples.ipynb
        deleted:    _proc/_docs/index.html
        deleted:    _proc/_docs/index_files/figure-commonmark/cell-3-output-1.svg
        deleted:    _proc/_docs/robots.txt
        deleted:    _proc/_docs/sitemap.xml
        modified:   _proc/index.ipynb
        modified:   index.ipynb

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        _proc/README.md

no changes added to commit (use "git add" and/or "git commit -a")
```

Copy paste from terminal below what I get after running nbdev_prepare:

```
nbdev_prepare
Success.
/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py:186: UserWarning: Found cells containing imports and other code. See FAQ.
---
#| include: false
import warnings
warnings.filterwarnings("ignore")
from nbdev.showdoc import show_doc
from IPython.display import HTML
import copy
#%load_ext autoreload
#%autoreload 2
---

  warn(f'Found cells containing imports and other code. See FAQ.\n---\n{cell.source}\n---\n')
/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py:186: UserWarning: Found cells containing imports and other code. See FAQ.
---
#| include: false
import warnings
warnings.filterwarnings("ignore")
from nbdev.showdoc import show_doc
from IPython.display import HTML
#%load_ext autoreload
#%autoreload 2
---

  warn(f'Found cells containing imports and other code. See FAQ.\n---\n{cell.source}\n---\n')
/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py:186: UserWarning: Found cells containing imports and other code. See FAQ.
---
#| include: false
import warnings
warnings.filterwarnings("ignore")
from nbdev.showdoc import show_doc
from IPython.display import HTML
#%load_ext autoreload
#%autoreload 2
---

  warn(f'Found cells containing imports and other code. See FAQ.\n---\n{cell.source}\n---\n')
/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py:186: UserWarning: Found cells containing imports and other code. See FAQ.
---
#| include: false
import warnings
warnings.filterwarnings("ignore")
from nbdev.showdoc import show_doc
from IPython.display import HTML
#%load_ext autoreload
#%autoreload 2
---

  warn(f'Found cells containing imports and other code. See FAQ.\n---\n{cell.source}\n---\n')
concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-e02b70aa1e17>", line 3, in <module>
    show_doc(equal_repeats)
NameError: name 'equal_repeats' is not defined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 198, in _process_chunk
    return [fn(*args) for args in chunk]
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 198, in <listcomp>
    return [fn(*args) for args in chunk]
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/parallel.py", line 46, in _call
    return g(item)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/serve_drv.py", line 22, in main
    if src.suffix=='.ipynb': exec_nb(src, dst, x)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/serve_drv.py", line 16, in exec_nb
    cb()(nb)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py", line 243, in __call__
    def __call__(self, nb): return self.nb_proc(nb).process()
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/process.py", line 127, in process
    for proc in self.procs: self._proc(proc)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/process.py", line 120, in _proc
    for cell in self.nb.cells: self._process_cell(proc, cell)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/process.py", line 111, in _process_cell
    if callable(proc) and not _is_direc(proc): cell = opt_set(cell, proc(cell))
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/processors.py", line 205, in __call__
    raise Exception(f"Error{' in notebook: '+title if title else ''} in cell {cell.idx_} :\n{cell.source}") from self.k.exc[1]
Exception: Error in notebook: motif in cell 100 :
#| echo: false
#| output: asis
show_doc(equal_repeats)
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/xerhma/.local/bin/nbdev_prepare", line 8, in <module>
    sys.exit(prepare())
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/script.py", line 119, in _f
    return tfunc(**merge(args, args_from_prog(func, xtra)))
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/quarto.py", line 287, in prepare
    nbdev_readme.__wrapped__(chk_time=True)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/quarto.py", line 259, in nbdev_readme
    cache = proc_nbs(path)
  File "/home/xerhma/.local/lib/python3.8/site-packages/nbdev/serve.py", line 77, in proc_nbs
    parallel(nbdev.serve_drv.main, files, n_workers=n_workers, pause=0.01, **kw)
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/parallel.py", line 117, in parallel
    return L(r)
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/foundation.py", line 98, in __call__
    return super().__call__(x, *args, **kwargs)
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/foundation.py", line 106, in __init__
    items = listify(items, *rest, use_list=use_list, match=match)
  File "/home/xerhma/.local/lib/python3.8/site-packages/fastcore/basics.py", line 66, in listify
    elif is_iter(o): res = list(o)
  File "/usr/lib/python3.8/concurrent/futures/process.py", line 484, in _chain_from_iterable_of_lists
    for element in iterable:
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 619, in result_iterator
    yield fs.pop().result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
Exception: Error in notebook: motif in cell 100 :
#| echo: false
#| output: asis
show_doc(equal_repeats)
```