### PR TITLE
GlycoDraw now checks for file extensions only

### DIFF
--- a/glycowork/motif/draw.py
+++ b/glycowork/motif/draw.py
@@ -2409,10 +2409,10 @@ def GlycoDraw(draw_this, vertical = False, compact = False, show_linkage = True,
       data = re.sub(r'<text font-size="17.5" ', r'<text font-size="17.5" font-family="century gothic" font-weight="bold" ', data)
       data = re.sub(r'<text font-size="20.0" ', r'<text font-size="20" font-family="century gothic" ', data)
       data = re.sub(r'<text font-size="15.0" ', r'<text font-size="17.5" font-family="century gothic" font-style="italic" ', data)
-      if 'svg' in filepath:
+      if filepath.endswith('.svg'):
         with open(filepath, 'w') as f:
           f.write(data)
-      elif 'pdf' in filepath:
+      elif filepath.endswith('.pdf'):
         try:
           from cairosvg import svg2pdf
           svg2pdf(bytestring = data, write_to = filepath)


### PR DESCRIPTION
On dev, GlycoDraw checks if "svg" or "pdf" are present in the `filepath`. Therefore, `GlycoDraw(..., filepath=/path/to/svg_data/glcan.pdf)` would have resulted in drawing as SVG. Now, GlycoDraw checks only the file extension to be ".pdf" or ".svg".