### PR TITLE
Rework of train_model function

### DIFF
--- a/bin/glycoworkGUI.py
+++ b/bin/glycoworkGUI.py
@@ -121,13 +121,13 @@ class GlycoDrawExcelDialog(simpledialog.Dialog):
                 self.tooltip.destroy()
         widget.bind('<Enter>', enter)
         widget.bind('<Leave>', leave)
-    
+
     def browse_csv(self):
         file_path = filedialog.askopenfilename(filetypes = [("CSV Files", "*.csv"), ("Excel Files", "*.xlsx")])
         if file_path:
             self.csv_entry.delete(0, tk.END)
             self.csv_entry.insert(0, file_path)
-    
+
     def browse_folder(self):
         folder_path = filedialog.askdirectory()
         if folder_path:
@@ -154,7 +154,7 @@ def openGlycoDrawExcelDialog():
 class DifferentialExpressionDialog(simpledialog.Dialog):
     def body(self, master):
         self.title("Differential Expression Input")
-        
+
         # CSV file selection
         tk.Label(master, text="CSV or Excel File:").grid(row = 0, sticky = tk.W)
         self.csv_file_var = tk.StringVar(master)
@@ -176,23 +176,23 @@ class DifferentialExpressionDialog(simpledialog.Dialog):
         self.output_folder_entry.grid(row = 4, column = 1)
         self.output_folder_browse = tk.Button(master, text = "Browse...", command = self.browse_output_folder)
         self.output_folder_browse.grid(row = 4, column = 2)
-        
+
         # Treatment group indices
         tk.Label(master, text = "Treatment Group Columns:").grid(row = 1, sticky = tk.W)
         self.treatment_entry = tk.Entry(master)
         self.treatment_entry.grid(row = 1, column = 1, columnspan = 2, sticky = tk.W+tk.E)
-        
+
         # Control group indices
         tk.Label(master, text = "Control Group Columns:").grid(row = 2, sticky = tk.W)
         self.control_entry = tk.Entry(master)
         self.control_entry.grid(row = 2, column = 1, columnspan = 2, sticky = tk.W+tk.E)
-        
+
         # Motifs option
         tk.Label(master, text="Motif-based analysis:").grid(row = 3, sticky = tk.W)
         self.motifs_var = tk.BooleanVar(master)
         self.motifs_check = tk.Checkbutton(master, variable = self.motifs_var)
         self.motifs_check.grid(row = 3, column = 1, sticky = tk.W)
-        
+
         return self.csv_entry  # to put focus on the csv file entry widget
 
     def create_tooltip(self, widget, text):
@@ -262,7 +262,7 @@ def openDifferentialExpressionDialog():
 class GetHeatmapDialog(simpledialog.Dialog):
     def body(self, master):
         self.title("Get Heatmap Input")
-        
+
         # Input file selection
         tk.Label(master, text = "Select Input CSV or Excel File:").grid(row = 0, sticky = tk.W)
         self.input_file_entry = tk.StringVar(master)
@@ -276,7 +276,7 @@ class GetHeatmapDialog(simpledialog.Dialog):
                             "Ideally, rows are samples and columns are glycans (but the function can deal with the opposite)\n"
                             "Glycans should be ideally in IUPAC-condensed\n"
                             "If you do NOT analyze motifs, the glycan format does not matter at all")
-        
+
         # Motif analysis option
         self.motif_analysis_var = tk.BooleanVar()
         self.motif_analysis_check = tk.Checkbutton(master, text = "Motif Analysis", variable = self.motif_analysis_var)
@@ -291,7 +291,7 @@ class GetHeatmapDialog(simpledialog.Dialog):
         self.show_all_var = tk.BooleanVar()
         self.show_all_check = tk.Checkbutton(master, text = "Show all?", variable = self.show_all_var)
         self.show_all_check.grid(row = 1, column = 2, sticky = tk.W)
-        
+
         # Output PDF file selection
         tk.Label(master, text = "Select Output for Heatmap File:").grid(row = 2, sticky = tk.W)
         self.output_file_entry = tk.StringVar(master)
@@ -360,7 +360,7 @@ def openGetHeatmapDialog():
 class LectinArrayAnalysisDialog(simpledialog.Dialog):
     def body(self, master):
         self.title("Lectin Array Analysis Input")
-        
+
         # CSV or Excel file selection
         tk.Label(master, text="Select CSV or Excel File:").grid(row = 0, sticky = tk.W)
         self.file_entry = tk.Entry(master)
@@ -372,17 +372,17 @@ class LectinArrayAnalysisDialog(simpledialog.Dialog):
         self.create_tooltip(self.help_icon, "CSV Format Help:\n\n"
                             "Format data as samples as rows and lectins as columns (first column = sample names)\n"
                             "Have lectin names in the column names")
-        
+
         # Treatment group indices
         tk.Label(master, text = "Treatment Group Rows (comma-separated):").grid(row = 1, sticky = tk.W)
         self.treatment_entry = tk.Entry(master)
         self.treatment_entry.grid(row = 1, column = 1, columnspan = 2, sticky = tk.W+tk.E)
-        
+
         # Control group indices
         tk.Label(master, text = "Control Group Rows (comma-separated):").grid(row = 2, sticky = tk.W)
         self.control_entry = tk.Entry(master)
         self.control_entry.grid(row = 2, column = 1, columnspan = 2, sticky = tk.W+tk.E)
-        
+
         # Paired analysis option
         tk.Label(master, text = "Paired Analysis:").grid(row = 3, sticky = tk.W)
         self.paired_var = tk.BooleanVar()

--- a/glycowork/glycan_data/data_entry.py
+++ b/glycowork/glycan_data/data_entry.py
@@ -1,9 +1,10 @@
+import pandas as pd
 from glycowork.motif.processing import check_nomenclature
 from glycowork.motif.graph import glycan_to_nxGraph, compare_glycans
 
 
-def check_presence(glycan, df, colname = 'glycan',
-                   name = None, rank = 'Species', fast = False):
+def check_presence(glycan: str, df: pd.DataFrame, colname: str = 'glycan', 
+                  name: str | None = None, rank: str = 'Species', fast: bool = False) -> None:
   """checks whether glycan (of that species) is already present in dataset\n
   | Arguments:
   | :-
@@ -14,8 +15,7 @@ def check_presence(glycan, df, colname = 'glycan',
   | fast (bool): True uses precomputed glycan graphs, only use if df has column 'graph' with glycan graphs\n
   | Returns:
   | :-
-  | Returns text output regarding whether the glycan is already in df
-  """
+  | Returns text output regarding whether the glycan is already in df"""
   if any([p in glycan for p in ['RES', '=']]) or not isinstance(glycan, str):
     check_nomenclature(glycan)
     return

--- a/glycowork/glycan_data/data_entry.py
+++ b/glycowork/glycan_data/data_entry.py
@@ -1,21 +1,17 @@
 import pandas as pd
+from typing import Optional
 from glycowork.motif.processing import check_nomenclature
 from glycowork.motif.graph import glycan_to_nxGraph, compare_glycans
 
 
-def check_presence(glycan: str, df: pd.DataFrame, colname: str = 'glycan', 
-                  name: str | None = None, rank: str = 'Species', fast: bool = False) -> None:
-  """checks whether glycan (of that species) is already present in dataset\n
-  | Arguments:
-  | :-
-  | glycan (string): IUPAC-condensed glycan sequence
-  | df (dataframe): glycan dataframe where glycans are under colname and ideally taxonomic labels are columns
-  | name (string): name of the species (etc.) of interest
-  | rank (string): column name for filtering; default: species
-  | fast (bool): True uses precomputed glycan graphs, only use if df has column 'graph' with glycan graphs\n
-  | Returns:
-  | :-
-  | Returns text output regarding whether the glycan is already in df"""
+def check_presence(glycan: str, # IUPAC-condensed glycan sequence
+                  df: pd.DataFrame, # glycan dataframe where glycans are under colname
+                  colname: str = 'glycan', # column name containing glycans
+                  name: Optional[str] = None, # name of species of interest
+                  rank: str = 'Species', # column name for filtering
+                  fast: bool = False # True uses precomputed glycan graphs
+                 ) -> None:
+  "checks whether glycan (of that species) is already present in dataset"
   if any([p in glycan for p in ['RES', '=']]) or not isinstance(glycan, str):
     check_nomenclature(glycan)
     return

--- a/glycowork/glycan_data/loader.py
+++ b/glycowork/glycan_data/loader.py
@@ -6,7 +6,7 @@ from pickle import load
 from os import path
 from itertools import chain
 from importlib import resources
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 with resources.open_text("glycowork.glycan_data", "glycan_motifs.csv") as f:
   motif_list = pd.read_csv(f)
@@ -212,7 +212,7 @@ def replace_every_second(string, old_char, new_char):
   | old_char (string): a string character to be replaced (every second occurrence)
   | new_char (string): the string character to replace old_char with\n
   | Returns:
-  | :-                           
+  | :-
   | Returns string with replaced characters
   """
   count = 0
@@ -285,7 +285,7 @@ def download_model(file_id, local_path = 'model_weights.pt'):
 class DataFrameSerializer:
   """A utility class for serializing and deserializing pandas DataFrames with complex data types
   in a version-independent manner."""
-  
+
   @staticmethod
   def _serialize_cell(value: Any) -> Dict[str, Any]:
     """Convert a cell value to a serializable format with type information."""
@@ -334,7 +334,7 @@ class DataFrameSerializer:
   @classmethod
   def serialize(cls, df: pd.DataFrame, path: str) -> None:
     """Serialize a DataFrame to JSON with type information.
-    
+
     Args:
       df: pandas DataFrame to serialize
       path: file path to save the serialized data"""
@@ -343,31 +343,31 @@ class DataFrameSerializer:
       'index': list(df.index),
       'data': []
     }
-    
+
     for _, row in df.iterrows():
       serialized_row = [cls._serialize_cell(val) for val in row]
       data['data'].append(serialized_row)
-    
+
     with open(path, 'w') as f:
       json.dump(data, f)
 
   @classmethod
   def deserialize(cls, path: str) -> pd.DataFrame:
     """Deserialize a DataFrame from JSON.
-    
+
     Args:
       path: file path to load the serialized data from
-    
+
     Returns:
       pandas DataFrame with restored data types"""
     with open(path, 'r') as f:
       data = json.load(f)
-    
+
     deserialized_data = []
     for row in data['data']:
       deserialized_row = [cls._deserialize_cell(cell) for cell in row]
       deserialized_data.append(deserialized_row)
-    
+
     return pd.DataFrame(
       data = deserialized_data,
       columns = data['columns'],

--- a/glycowork/glycan_data/loader.py
+++ b/glycowork/glycan_data/loader.py
@@ -6,7 +6,7 @@ from pickle import load
 from os import path
 from itertools import chain
 from importlib import resources
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 with resources.open_text("glycowork.glycan_data", "glycan_motifs.csv") as f:
   motif_list = pd.read_csv(f)
@@ -85,12 +85,12 @@ modification_map = {'6S': {'GlcNAc', 'Gal'}, '3S': {'Gal'}, '4S': {'GalNAc'},
                     'OS': {'GlcNAc', 'Gal', 'GalNAc'}}
 
 
-def unwrap(nested_list):
+def unwrap(nested_list: list) -> list:
   """converts a nested list into a flat list"""
   return list(chain(*nested_list))
 
 
-def find_nth(haystack, needle, n):
+def find_nth(haystack: str, needle: str, n: int) -> int:
   """finds n-th instance of motif\n
   | Arguments:
   | :-
@@ -99,8 +99,7 @@ def find_nth(haystack, needle, n):
   | n (int): n-th occurrence in string (not zero-indexed)\n
   | Returns:
   | :-
-  | Returns starting index of n-th occurrence in string
-  """
+  | Returns starting index of n-th occurrence in string"""
   start = haystack.find(needle)
   while start >= 0 and n > 1:
     start = haystack.find(needle, start+len(needle))
@@ -108,7 +107,7 @@ def find_nth(haystack, needle, n):
   return start
 
 
-def find_nth_reverse(string, substring, n, ignore_branches = False):
+def find_nth_reverse(string: str, substring: str, n: int, ignore_branches: bool = False) -> int:
   # Reverse the string and the substring
   reversed_string = string[::-1]
   reversed_substring = substring[::-1]
@@ -142,15 +141,14 @@ def find_nth_reverse(string, substring, n, ignore_branches = False):
   return original_start_index
 
 
-def remove_unmatched_brackets(s):
+def remove_unmatched_brackets(s: str) -> str:
   """Removes all unmatched brackets from the string s.\n
   | Arguments:
   | :-
   | s (string): glycan string in IUPAC-condensed\n
   | Returns:
   | :-
-  | Returns glycan without unmatched brackets
-   """
+  | Returns glycan without unmatched brackets"""
   while True:
     # Keep track of the indexes of the brackets
     stack = []
@@ -173,7 +171,7 @@ def remove_unmatched_brackets(s):
   return s
 
 
-def reindex(df_new, df_old, out_col, ind_col, inp_col):
+def reindex(df_new: pd.DataFrame, df_old: pd.DataFrame, out_col: str, ind_col: str, inp_col: str) -> list:
   """Returns columns values in order of new dataframe rows\n
   | Arguments:
   | :-
@@ -184,27 +182,25 @@ def reindex(df_new, df_old, out_col, ind_col, inp_col):
   | inp_col (string): column name of column in df_new that indicates the new order; ind_col and inp_col should match\n
   | Returns:
   | :-
-  | Returns out_col from df_old in the same order of inp_col in df_new
-  """
+  | Returns out_col from df_old in the same order of inp_col in df_new"""
   if ind_col != inp_col:
     print("Mismatching column names for ind_col and inp_col. Doesn't mean it's wrong but pay attention.")
   return [df_old[out_col].values.tolist()[df_old[ind_col].values.tolist().index(k)] for k in df_new[inp_col].values.tolist()]
 
 
-def stringify_dict(dicty):
+def stringify_dict(dicty: dict) -> str:
   """Converts dictionary into a string\n
   | Arguments:
   | :-
   | dicty (dictionary): dictionary\n
   | Returns:
   | :-
-  | Returns string of type key:value for sorted items
-  """
+  | Returns string of type key:value for sorted items"""
   dicty = dict(sorted(dicty.items()))
   return ''.join(f"{key}{value}" for key, value in dicty.items())
 
 
-def replace_every_second(string, old_char, new_char):
+def replace_every_second(string: str, old_char: str, new_char: str) -> str:
   """function to replace every second occurrence of old_char in string with new_char\n
   | Arguments:
   | :-
@@ -213,8 +209,7 @@ def replace_every_second(string, old_char, new_char):
   | new_char (string): the string character to replace old_char with\n
   | Returns:
   | :-
-  | Returns string with replaced characters
-  """
+  | Returns string with replaced characters"""
   count = 0
   result = []
   for char in string:
@@ -226,7 +221,7 @@ def replace_every_second(string, old_char, new_char):
   return ''.join(result)
 
 
-def multireplace(string, remove_dic):
+def multireplace(string: str, remove_dic: dict[str, str]) -> str:
   """Replaces all occurences of items in a set with a given string\n
   | Arguments:
   | :-
@@ -234,19 +229,18 @@ def multireplace(string, remove_dic):
   | remove_dic (set): dict of form to_replace:replace_with\n
   | Returns:
   | :-
-  | (str) modified string
-  """
+  | (str) modified string"""
   for k, v in remove_dic.items():
     string = string.replace(k, v)
   return string
 
 
-def strip_suffixes(columns):
+def strip_suffixes(columns: list) -> list[str]:
   """Strip numerical suffixes like .1, .2, etc., from column names."""
   return [re.sub(r"\.\d+$", "", str(name)) for name in columns]
 
 
-def build_custom_df(df, kind = 'df_species'):
+def build_custom_df(df: pd.DataFrame, kind: str = 'df_species') -> pd.DataFrame:
   """creates custom df from df_glycan\n
   | Arguments:
   | :-
@@ -254,8 +248,7 @@ def build_custom_df(df, kind = 'df_species'):
   | kind (string): whether to create 'df_species', 'df_tissue', or 'df_disease' from df_glycan; default:df_species\n
   | Returns:
   | :-
-  | Returns custom df in the form of one glycan - species/tissue/disease association per row
-  """
+  | Returns custom df in the form of one glycan - species/tissue/disease association per row"""
   kind_to_cols = {
         'df_species': ['glycan', 'Species', 'Genus', 'Family', 'Order', 'Class',
                        'Phylum', 'Kingdom', 'Domain', 'ref'],
@@ -274,7 +267,7 @@ def build_custom_df(df, kind = 'df_species'):
   return df
 
 
-def download_model(file_id, local_path = 'model_weights.pt'):
+def download_model(file_id: str, local_path: str = 'model_weights.pt') -> None:
   """Download the model weights file from Google Drive."""
   file_id = file_id.split('/d/')[1].split('/view')[0]
   url = f'https://drive.google.com/uc?id={file_id}'

--- a/glycowork/glycan_data/loader.py
+++ b/glycowork/glycan_data/loader.py
@@ -6,7 +6,7 @@ from pickle import load
 from os import path
 from itertools import chain
 from importlib import resources
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 with resources.open_text("glycowork.glycan_data", "glycan_motifs.csv") as f:
   motif_list = pd.read_csv(f)
@@ -85,21 +85,17 @@ modification_map = {'6S': {'GlcNAc', 'Gal'}, '3S': {'Gal'}, '4S': {'GalNAc'},
                     'OS': {'GlcNAc', 'Gal', 'GalNAc'}}
 
 
-def unwrap(nested_list: list) -> list:
-  """converts a nested list into a flat list"""
+def unwrap(nested_list: List[Any] # list to be flattened
+         ) -> List[Any]: # flattened list
+  "converts a nested list into a flat list"
   return list(chain(*nested_list))
 
 
-def find_nth(haystack: str, needle: str, n: int) -> int:
-  """finds n-th instance of motif\n
-  | Arguments:
-  | :-
-  | haystack (string): string to search for motif
-  | needle (string): motif
-  | n (int): n-th occurrence in string (not zero-indexed)\n
-  | Returns:
-  | :-
-  | Returns starting index of n-th occurrence in string"""
+def find_nth(haystack: str, # string to search for motif
+            needle: str, # motif
+            n: int # n-th occurrence in string (not zero-indexed)
+           ) -> int: # starting index of n-th occurrence
+  "finds n-th instance of motif"
   start = haystack.find(needle)
   while start >= 0 and n > 1:
     start = haystack.find(needle, start+len(needle))
@@ -107,7 +103,12 @@ def find_nth(haystack: str, needle: str, n: int) -> int:
   return start
 
 
-def find_nth_reverse(string: str, substring: str, n: int, ignore_branches: bool = False) -> int:
+def find_nth_reverse(string: str, # string to search
+                    substring: str, # substring to find
+                    n: int, # n-th occurrence from end
+                    ignore_branches: bool = False # whether to ignore branches when counting
+                   ) -> int: # position of n-th occurrence from end
+  "finds n-th instance of motif from end of string"
   # Reverse the string and the substring
   reversed_string = string[::-1]
   reversed_substring = substring[::-1]
@@ -141,14 +142,9 @@ def find_nth_reverse(string: str, substring: str, n: int, ignore_branches: bool 
   return original_start_index
 
 
-def remove_unmatched_brackets(s: str) -> str:
-  """Removes all unmatched brackets from the string s.\n
-  | Arguments:
-  | :-
-  | s (string): glycan string in IUPAC-condensed\n
-  | Returns:
-  | :-
-  | Returns glycan without unmatched brackets"""
+def remove_unmatched_brackets(s: str # glycan string in IUPAC-condensed
+                           ) -> str: # glycan without unmatched brackets
+  "Removes all unmatched brackets from the string s"
   while True:
     # Keep track of the indexes of the brackets
     stack = []
@@ -171,45 +167,30 @@ def remove_unmatched_brackets(s: str) -> str:
   return s
 
 
-def reindex(df_new: pd.DataFrame, df_old: pd.DataFrame, out_col: str, ind_col: str, inp_col: str) -> list:
-  """Returns columns values in order of new dataframe rows\n
-  | Arguments:
-  | :-
-  | df_new (pandas dataframe): dataframe with the new row order
-  | df_old (pandas dataframe): dataframe with the old row order
-  | out_col (string): column name of column in df_old that you want to reindex
-  | ind_col (string): column name of column in df_old that will give the index
-  | inp_col (string): column name of column in df_new that indicates the new order; ind_col and inp_col should match\n
-  | Returns:
-  | :-
-  | Returns out_col from df_old in the same order of inp_col in df_new"""
+def reindex(df_new: pd.DataFrame, # dataframe with new row order
+           df_old: pd.DataFrame, # dataframe with old row order
+           out_col: str, # column name in df_old to reindex
+           ind_col: str, # column name in df_old for index
+           inp_col: str # column name in df_new for new order
+          ) -> list: # out_col from df_old reordered to match inp_col in df_new
+  "Returns columns values in order of new dataframe rows"
   if ind_col != inp_col:
     print("Mismatching column names for ind_col and inp_col. Doesn't mean it's wrong but pay attention.")
   return [df_old[out_col].values.tolist()[df_old[ind_col].values.tolist().index(k)] for k in df_new[inp_col].values.tolist()]
 
 
-def stringify_dict(dicty: dict) -> str:
-  """Converts dictionary into a string\n
-  | Arguments:
-  | :-
-  | dicty (dictionary): dictionary\n
-  | Returns:
-  | :-
-  | Returns string of type key:value for sorted items"""
+def stringify_dict(dicty: Dict[Any, Any] # dictionary to convert
+                 ) -> str: # string of type key:value for sorted items
+  "Converts dictionary into a string"
   dicty = dict(sorted(dicty.items()))
   return ''.join(f"{key}{value}" for key, value in dicty.items())
 
 
-def replace_every_second(string: str, old_char: str, new_char: str) -> str:
-  """function to replace every second occurrence of old_char in string with new_char\n
-  | Arguments:
-  | :-
-  | string (string): a string
-  | old_char (string): a string character to be replaced (every second occurrence)
-  | new_char (string): the string character to replace old_char with\n
-  | Returns:
-  | :-
-  | Returns string with replaced characters"""
+def replace_every_second(string: str, # input string
+                        old_char: str, # character to replace
+                        new_char: str # character to replace with
+                       ) -> str: # modified string
+  "function to replace every second occurrence of old_char in string with new_char"
   count = 0
   result = []
   for char in string:
@@ -221,34 +202,25 @@ def replace_every_second(string: str, old_char: str, new_char: str) -> str:
   return ''.join(result)
 
 
-def multireplace(string: str, remove_dic: dict[str, str]) -> str:
-  """Replaces all occurences of items in a set with a given string\n
-  | Arguments:
-  | :-
-  | string (str): string to perform replacements on
-  | remove_dic (set): dict of form to_replace:replace_with\n
-  | Returns:
-  | :-
-  | (str) modified string"""
+def multireplace(string: str, # string to perform replacements on
+                remove_dic: Dict[str, str] # dict of form to_replace:replace_with
+               ) -> str: # modified string
+  "Replaces all occurences of items in a set with a given string"
   for k, v in remove_dic.items():
     string = string.replace(k, v)
   return string
 
 
-def strip_suffixes(columns: list) -> list[str]:
-  """Strip numerical suffixes like .1, .2, etc., from column names."""
+def strip_suffixes(columns: List[Any] # column names
+                 ) -> List[str]: # column names without numerical suffixes
+  "Strip numerical suffixes like .1, .2, etc., from column names"
   return [re.sub(r"\.\d+$", "", str(name)) for name in columns]
 
 
-def build_custom_df(df: pd.DataFrame, kind: str = 'df_species') -> pd.DataFrame:
-  """creates custom df from df_glycan\n
-  | Arguments:
-  | :-
-  | df (dataframe): df_glycan / sugarbase
-  | kind (string): whether to create 'df_species', 'df_tissue', or 'df_disease' from df_glycan; default:df_species\n
-  | Returns:
-  | :-
-  | Returns custom df in the form of one glycan - species/tissue/disease association per row"""
+def build_custom_df(df: pd.DataFrame, # df_glycan / sugarbase
+                   kind: str = 'df_species' # whether to create 'df_species', 'df_tissue', or 'df_disease'
+                  ) -> pd.DataFrame: # custom df with one glycan - species/tissue/disease association per row
+  "creates custom df from df_glycan"
   kind_to_cols = {
         'df_species': ['glycan', 'Species', 'Genus', 'Family', 'Order', 'Class',
                        'Phylum', 'Kingdom', 'Domain', 'ref'],
@@ -267,8 +239,10 @@ def build_custom_df(df: pd.DataFrame, kind: str = 'df_species') -> pd.DataFrame:
   return df
 
 
-def download_model(file_id: str, local_path: str = 'model_weights.pt') -> None:
-  """Download the model weights file from Google Drive."""
+def download_model(file_id: str, # Google Drive file ID
+                  local_path: str = 'model_weights.pt' # where to save model file
+                 ) -> None:
+  "Download the model weights file from Google Drive"
   file_id = file_id.split('/d/')[1].split('/view')[0]
   url = f'https://drive.google.com/uc?id={file_id}'
   gdown.download(url, local_path, quiet = False)
@@ -325,12 +299,10 @@ class DataFrameSerializer:
       return cell_data['value']
 
   @classmethod
-  def serialize(cls, df: pd.DataFrame, path: str) -> None:
-    """Serialize a DataFrame to JSON with type information.
-
-    Args:
-      df: pandas DataFrame to serialize
-      path: file path to save the serialized data"""
+  def serialize(cls, df: pd.DataFrame, # DataFrame to serialize
+                 path: str # file path to save serialized data
+                ) -> None:
+    "Serialize a DataFrame to JSON with type information"
     data = {
       'columns': list(df.columns),
       'index': list(df.index),
@@ -345,14 +317,9 @@ class DataFrameSerializer:
       json.dump(data, f)
 
   @classmethod
-  def deserialize(cls, path: str) -> pd.DataFrame:
-    """Deserialize a DataFrame from JSON.
-
-    Args:
-      path: file path to load the serialized data from
-
-    Returns:
-      pandas DataFrame with restored data types"""
+  def deserialize(cls, path: str # file path to load serialized data
+                  ) -> pd.DataFrame: # DataFrame with restored data types
+    "Deserialize a DataFrame from JSON"
     with open(path, 'r') as f:
       data = json.load(f)
 

--- a/glycowork/glycan_data/stats.py
+++ b/glycowork/glycan_data/stats.py
@@ -6,7 +6,7 @@ from collections import defaultdict, Counter
 from sklearn.linear_model import Ridge
 from sklearn.ensemble import RandomForestRegressor
 from scipy.special import gammaln
-from scipy.stats import wilcoxon, rankdata, norm, chi2, t, f, entropy, gmean, f_oneway, combine_pvalues, dirichlet
+from scipy.stats import wilcoxon, rankdata, norm, chi2, t, f, entropy, gmean, f_oneway, combine_pvalues, dirichlet, spearmanr, ttest_rel
 from scipy.stats.mstats import winsorize
 from scipy.spatial import procrustes
 from scipy.spatial.distance import squareform
@@ -1190,7 +1190,7 @@ def perform_tests_monte_carlo(group_a, group_b, num_instances = 128, paired = Fa
   | (i) list of uncorrected p-values
   | (ii) list of corrected p-values (two-stage Benjamini-Hochberg)
   | (ii) list of effect sizes (Cohen's d)"""
-  num_features, num_columns = group_a.shape
+  num_features, _ = group_a.shape
   avg_uncorrected_p_values, avg_corrected_p_values, avg_effect_sizes = np.zeros(num_features), np.zeros(num_features), np.zeros(num_features)
   for instance in range(num_instances):
     instance_p_values = []
@@ -1199,7 +1199,7 @@ def perform_tests_monte_carlo(group_a, group_b, num_instances = 128, paired = Fa
       sample_a = group_a.iloc[feature, instance::num_instances].values
       sample_b = group_b.iloc[feature, instance::num_instances].values
       p_value = ttest_rel(sample_b, sample_a)[1] if paired else ttest_ind(sample_b, sample_a, equal_var = False)[1]
-      effect_size, effect_size_variance = cohen_d(sample_b, sample_a, paired = paired)
+      effect_size, _ = cohen_d(sample_b, sample_a, paired = paired)
       instance_p_values.append(p_value)
       instance_effect_sizes.append(effect_size)
     # Apply Benjamini-Hochberg correction for multiple testing within the instance

--- a/glycowork/glycan_data/stats.py
+++ b/glycowork/glycan_data/stats.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import math
 import warnings
+from typing import Dict, List, Optional, Tuple, Union
 from collections import defaultdict, Counter
 from sklearn.linear_model import Ridge
 from sklearn.ensemble import RandomForestRegressor
@@ -23,22 +24,27 @@ rng = np.random.default_rng(42)
 np.random.seed(0)
 
 
-def fast_two_sum(a: int | float, b: int | float) -> list[int]:
-  """Assume abs(a) >= abs(b)"""
+def fast_two_sum(a: Union[int, float], # first number (assume abs(a) >= abs(b))
+                b: Union[int, float] # second number
+               ) -> List[int]: # list containing sum
+  "Assume abs(a) >= abs(b)"
   x = int(a) + int(b)
   y = b - (x - int(a))
   return [x] if y == 0 else [x, y]
 
 
-def two_sum(a: int | float, b: int | float) -> list[int]:
-  """For unknown order of a and b"""
+def two_sum(a: Union[int, float], # first number
+           b: Union[int, float] # second number
+          ) -> List[int]: # list containing sum
+  "For unknown order of a and b"
   x = int(a) + int(b)
   y = (a - (x - int(b))) + (b - (x - int(a)))
   return [x] if y == 0 else [x, y]
 
 
-def expansion_sum(*args: int | float) -> int | list[int | float]:
-  """For the expansion sum of floating points"""
+def expansion_sum(*args: Union[int, float] # numbers to sum
+                ) -> Union[int, List[Union[int, float]]]: # sum as int or list
+  "For the expansion sum of floating points"
   g = sorted(args, reverse = True)
   q, *h = fast_two_sum(np.array(g[0]), np.array(g[1]))
   for val in g[2:]:
@@ -49,16 +55,21 @@ def expansion_sum(*args: int | float) -> int | list[int | float]:
   return [h, q] if h else q
 
 
-def hlm(z: np.ndarray | list[float]) -> float:
-  """Hodges-Lehmann estimator of the median"""
+def hlm(z: Union[np.ndarray, List[float]] # array of values
+       ) -> float: # median estimate
+  "Hodges-Lehmann estimator of the median"
   z = np.array(z)
   zz = np.add.outer(z, z)
   zz = zz[np.tril_indices(len(z))]
   return np.median(zz) / 2
 
 
-def update_cf_for_m_n(m: int, n: int, MM: int, cf: list[float]) -> None:
-  """Constructs cumulative frequency table for experimental parameters defined in the function 'jtkinit'"""
+def update_cf_for_m_n(m: int, # parameter m
+                     n: int, # parameter n
+                     MM: int, # maximum M value
+                     cf: List[float] # cumulative frequency table
+                    ) -> None: # updates cf in place
+  "Constructs cumulative frequency table for experimental parameters defined in 'jtkinit'"
   P = min(m + n, MM)
   for t_temp in range(n + 1, P + 1):  # Zero-based offset t_temp
     for u in range(MM, t_temp - 1, -1):  # One-based descending index u
@@ -69,16 +80,11 @@ def update_cf_for_m_n(m: int, n: int, MM: int, cf: list[float]) -> None:
       cf[u] = expansion_sum(cf[u], cf[u - s])  # Shewchuk algorithm
 
 
-def cohen_d(x: np.ndarray | list[float], y: np.ndarray | list[float], paired: bool = False) -> tuple[float, float]:
-  """calculates effect size between two groups\n
-  | Arguments:
-  | :-
-  | x (list or 1D-array): comparison group containing numerical data
-  | y (list or 1D-array): comparison group containing numerical data
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | Returns Cohen's d (and its variance) as a measure of effect size (0.2 small; 0.5 medium; 0.8 large)"""
+def cohen_d(x: Union[np.ndarray, List[float]], # comparison group containing numerical data
+           y: Union[np.ndarray, List[float]], # comparison group containing numerical data
+           paired: bool = False # whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient)
+          ) -> Tuple[float, float]: # (Cohen's d, variance) where d: 0.2 small; 0.5 medium; 0.8 large effect size
+  "calculates effect size between two groups"
   if paired:
     assert len(x) == len(y), "For paired samples, the size of x and y should be the same"
     diff = np.array(x) - np.array(y)
@@ -99,16 +105,11 @@ def cohen_d(x: np.ndarray | list[float], y: np.ndarray | list[float], paired: bo
   return d, var_d
 
 
-def mahalanobis_distance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFrame, paired: bool = False) -> float:
-  """calculates effect size between two groups in a multivariate comparison\n
-  | Arguments:
-  | :-
-  | x (list or 1D-array or dataframe): comparison group containing numerical data
-  | y (list or 1D-array or dataframe): comparison group containing numerical data
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | Returns Mahalanobis distance as a measure of effect size"""
+def mahalanobis_distance(x: Union[np.ndarray, pd.DataFrame], # comparison group containing numerical data
+                        y: Union[np.ndarray, pd.DataFrame], # comparison group containing numerical data
+                        paired: bool = False # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                       ) -> float: # Mahalanobis distance effect size
+  "calculates effect size between two groups in a multivariate comparison"
   if paired:
     assert x.shape == y.shape, "For paired samples, the size of x and y should be the same"
     x = np.array(x) - np.array(y)
@@ -123,16 +124,11 @@ def mahalanobis_distance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFr
   return mahalanobis_d[0][0]
 
 
-def mahalanobis_variance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFrame, paired: bool = False) -> float:
-  """Estimates variance of Mahalanobis distance via bootstrapping\n
-  | Arguments:
-  | :-
-  | x (list or 1D-array or dataframe): comparison group containing numerical data
-  | y (list or 1D-array or dataframe): comparison group containing numerical data
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | Returns Mahalanobis distance as a measure of effect size"""
+def mahalanobis_variance(x: Union[np.ndarray, pd.DataFrame], # comparison group containing numerical data
+                        y: Union[np.ndarray, pd.DataFrame], # comparison group containing numerical data
+                        paired: bool = False # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                       ) -> float: # variance of Mahalanobis distance
+  "Estimates variance of Mahalanobis distance via bootstrapping"
   # Combine gp1 and gp2 into a single matrix
   data = np.concatenate((x.T, y.T), axis = 0)
   # Perform bootstrap resampling
@@ -152,15 +148,10 @@ def mahalanobis_variance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFr
   return np.var(bootstrap_samples)
 
 
-def variance_stabilization(data: pd.DataFrame, groups: list[list[str]] | None = None) -> pd.DataFrame:
-  """Variance stabilization normalization\n
-  | Arguments:
-  | :-
-  | data (dataframe): pandas dataframe with glycans/motifs as indices and samples as columns
-  | groups (nested list): list containing lists of column names of samples from same group for group-specific normalization; otherwise global; default:None\n
-  | Returns:
-  | :-
-  | Returns a dataframe in the same style as the input"""
+def variance_stabilization(data: pd.DataFrame, # dataframe with glycans/motifs as indices and samples as columns
+                         groups: Union[List[List[str]], None] = None # list containing lists of column names of samples from same group for group-specific normalization; otherwise global
+                        ) -> pd.DataFrame: # normalized dataframe in same format as input
+  "performs variance stabilization normalization"
   # Apply log1p transformation
   data = np.log1p(data)
   # Scale data to have zero mean and unit variance
@@ -174,22 +165,18 @@ def variance_stabilization(data: pd.DataFrame, groups: list[list[str]] | None = 
 
 
 class MissForest:
-  """Parameters
-  (adapted from https://github.com/yuenshingyan/MissForest)
-  ----------
-  regressor : estimator object.
-  A object of that type is instantiated for each imputation.
-  This object is assumed to implement the scikit-learn estimator API.
-
-  n_iter : int
-  Determines the number of iterations for the imputation process."""
-  def __init__(self, regressor: RandomForestRegressor = RandomForestRegressor(n_jobs = -1),
-               max_iter: int = 5, tol: float = 1e-5) -> None:
+  def __init__(self, regressor: RandomForestRegressor = RandomForestRegressor(n_jobs = -1), # estimator object for each imputation
+                 max_iter: int = 5, # number of iterations for imputation process
+                 tol: float = 1e-5 # convergence tolerance
+                ) -> None:
+    "A class to perform MissForest imputation adapted from https://github.com/yuenshingyan/MissForest"
     self.regressor = regressor
     self.max_iter = max_iter
     self.tol = tol
 
-  def fit_transform(self, X: pd.DataFrame) -> pd.DataFrame:
+  def fit_transform(self, X: pd.DataFrame # input dataframe with missing values
+                    ) -> pd.DataFrame: # imputed dataframe
+    "Replace missing values using the MissForest algorithm"
     # Step 1: Initialization
     # Keep track of where NaNs are in the original dataset
     X_nan = X.isnull()
@@ -220,17 +207,12 @@ class MissForest:
     return X_transform
 
 
-def impute_and_normalize(df: pd.DataFrame, groups: list[list[str]], impute: bool = True, min_samples: float = 0.1) -> pd.DataFrame:
-    """given a dataframe, discards rows with too many missings, imputes the rest, and normalizes\n
-    | Arguments:
-    | :-
-    | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns
-    | groups (list): nested list of column name lists, one list per group
-    | impute (bool): replaces zeroes with predictions from MissForest; default:True
-    | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%\n
-    | Returns:
-    | :-
-    | Returns a dataframe in the same style as the input """
+def impute_and_normalize(df: pd.DataFrame, # dataframe with glycan sequences in first col and abundances in subsequent cols
+                        groups: List[List[str]], # nested list of column name lists, one list per group
+                        impute: bool = True, # replaces zeroes with predictions from MissForest
+                        min_samples: float = 0.1 # percent of samples that need non-zero values for glycan to be kept
+                       ) -> pd.DataFrame: # normalized dataframe in same style as input
+    "discards rows with too many missings, imputes the rest, and normalizes"
     if min_samples:
       min_count = max(np.floor(df.shape[1] * min_samples), 2) + 1
       mask = (df != 0).sum(axis = 1) >= min_count
@@ -257,34 +239,22 @@ def impute_and_normalize(df: pd.DataFrame, groups: list[list[str]], impute: bool
     return df
 
 
-def variance_based_filtering(df: pd.DataFrame, min_feature_variance: float = 0.02) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Variance-based filtering of features\n
-    | Arguments:
-    | :-
-    | df (dataframe): dataframe containing glycan sequences in index and samples in columns
-    | min_feature_variance (float): Minimum variance to include a feature in the analysis; default: 2%\n
-    | Returns:
-    | :-
-    | filtered_df (DataFrame): DataFrame with remaining glycans (variance > min_feature_variance) as indices and samples in columns.
-    | discarded_df (DataFrame): DataFrame with discarded glycans (variance <= min_feature_variance) as indices and samples in columns."""
-    variances = df.var(axis = 1)
-    filtered_df = df.loc[variances > min_feature_variance]
-    discarded_df = df.loc[variances <= min_feature_variance]
-    return filtered_df, discarded_df
+def variance_based_filtering(df: pd.DataFrame, # dataframe with glycans as index and samples in columns
+                           min_feature_variance: float = 0.02 # minimum variance to include a feature
+                          ) -> Tuple[pd.DataFrame, pd.DataFrame]: # (filtered df with variance > min, discarded df with variance <= min)
+  "Variance-based filtering of features"
+  variances = df.var(axis = 1)
+  filtered_df = df.loc[variances > min_feature_variance]
+  discarded_df = df.loc[variances <= min_feature_variance]
+  return filtered_df, discarded_df
 
 
-def jtkdist(timepoints: int | np.ndarray, param_dic: dict, reps: int = 1, normal: bool = False) -> dict:
-  """Precalculates all possible JT test statistic permutation probabilities for reference later, speeding up the
-  | analysis. Calculates the exact null distribution using the Harding algorithm.\n
-  | Arguments:
-  | :-
-  | timepoints (int): number of timepoints within the experiment.
-  | param_dic (dict): dictionary carrying around the parameter values
-  | reps (int): number of replicates within each timepoint.
-  | normal (bool): a flag for normal approximation if maximum possible negative log p-value is too large.\n
-  | Returns:
-  | :-
-  | Returns statistical values, added to 'param_dic'."""
+def jtkdist(timepoints: Union[int, np.ndarray], # number/array of timepoints within experiment
+           param_dic: Dict, # dictionary carrying parameter values
+           reps: int = 1, # number of replicates within each timepoint
+           normal: bool = False # flag for normal approximation if max possible negative log p-value too large
+          ) -> Dict: # updated param_dic with statistical values
+  "Precalculates all possible JT test statistic permutation probabilities for reference using the Harding algorithm"
   timepoints = timepoints if isinstance(timepoints, int) else timepoints.sum()
   tim = np.full(timepoints, reps) if reps != timepoints else reps  # Support for unbalanced replication (unequal replicates in all groups)
   maxnlp = gammaln(np.sum(tim)) - np.sum(np.log(np.arange(1, np.max(tim)+1)))
@@ -322,20 +292,12 @@ def jtkdist(timepoints: int | np.ndarray, param_dic: dict, reps: int = 1, normal
   return param_dic
 
 
-def jtkinit(periods: list[int], param_dic: dict, interval: int = 1, replicates: int = 1) -> dict:
-  """Defines the parameters of the simulated sine waves for reference later.\n
-  | Each molecular species within the analysis is matched to the optimal wave defined here, and the parameters
-  | describing that wave are attributed to the molecular species.\n
-  | Arguments:
-  | :-
-  | periods (list): the possible periods of rhytmicity in the biological data (valued as 'number of timepoints').
-  | (note: periods can accept multiple values (ie, you can define circadian rhythms as between 22, 24, 26 hours))
-  | param_dic (dict): dictionary carrying around the parameter values
-  | interval (int): the number of units of time (arbitrary) between each experimental timepoint.
-  | replicates (int): number of replicates within each group.\n
-  | Returns:
-  | :-
-  | Returns values describing waveforms, added to 'param_dic'."""
+def jtkinit(periods: List[int], # possible periods of rhythmicity in biological data (valued as 'number of timepoints')
+           param_dic: Dict, # dictionary carrying parameter values
+           interval: int = 1, # units of time between experimental timepoints
+           replicates: int = 1 # number of replicates within each group
+          ) -> Dict: # updated param_dic with waveform parameters
+  "Defines the parameters of the simulated sine waves for reference later"
   param_dic["INTERVAL"] = interval
   if len(periods) > 1:
     param_dic["PERIODS"] = list(periods)
@@ -391,16 +353,10 @@ def jtkinit(periods: list[int], param_dic: dict, interval: int = 1, replicates: 
   return param_dic
 
 
-def jtkstat(z: pd.DataFrame, param_dic: dict) -> dict:
-  """Determines the JTK statistic and p-values for all model phases, compared to expression data.\n
-  | Arguments:
-  | :-
-  | z (pd.DataFrame): expression data for a molecule ordered in groups, by timepoint.
-  | param_dic (dict): a dictionary containing parameters defining model waveforms.\n
-  | Returns:
-  | :-
-  | Returns an updated parameter dictionary where the appropriate model waveform has been assigned to the
-  | molecules in the analysis."""
+def jtkstat(z: pd.DataFrame, # expression data for a molecule ordered in groups by timepoint
+           param_dic: Dict # dictionary containing parameters defining model waveforms
+          ) -> Dict: # updated param_dic with appropriate model waveform assigned
+  "Determines the JTK statistic and p-values for all model phases, compared to expression data"
   param_dic["CJTK"] = []
   M = param_dic["MAX"]
   z = np.array(z)
@@ -424,16 +380,11 @@ def jtkstat(z: pd.DataFrame, param_dic: dict) -> dict:
   return param_dic
 
 
-def jtkx(z: pd.DataFrame, param_dic: dict, ampci: bool = False) -> pd.Series:
-  """Deployment of jtkstat for repeated use, and parameter extraction\n
-  | Arguments:
-  | :-
-  | z (pd.dataframe): expression data ordered in groups, by timepoint.
-  | param_dic (dict): a dictionary containing parameters defining model waveforms.
-  | ampci (bool): flag for calculating amplitude confidence interval (TRUE = compute); default=False.\n
-  | Returns:
-  | :-
-  | Returns an updated parameter dictionary containing the optimal waveform parameters for each molecular species."""
+def jtkx(z: pd.DataFrame, # expression data ordered in groups by timepoint
+        param_dic: Dict, # dictionary containing parameters defining model waveforms
+        ampci: bool = False # whether to calculate amplitude confidence interval
+       ) -> pd.Series: # optimal waveform parameters for each molecular species
+  "Deployment of jtkstat for repeated use, and parameter extraction"
   param_dic = jtkstat(z, param_dic)  # Calculate p and S for all phases
   padj = [cjtk[0] for cjtk in param_dic["CJTK"]]  # Exact two-tailed p values for period/phase combos
   #padj = multipletests(pvals, method = 'fdr_bh')[1]
@@ -477,18 +428,13 @@ def jtkx(z: pd.DataFrame, param_dic: dict, ampci: bool = False) -> pd.Series:
   return pd.Series([JTK_ADJP, JTK_PERIOD, JTK_LAG, JTK_AMP])
 
 
-def get_BF(n: int, p: float, z: bool = False, method: str = "robust", upper: float = 10) -> float:
-  """Transforms a p-value into Jeffreys' approximate Bayes factor (BF)\n
-  | Arguments:
-  | :-
-  | n (int): Sample size.
-  | p (float): The p-value.
-  | z (bool): True if the p-value is based on a z-statistic, False if t-statistic; default:False
-  | method (str): Method used for the choice of 'b'. Options are "JAB", "min", "robust", "balanced"; default:'robust'
-  | upper (float): The upper limit for the range of realistic effect sizes. Only relevant when method="balanced"; default:10\n
-  | Returns:
-  | :-
-  | float: A numeric value for the BF in favour of H1."""
+def get_BF(n: int, # sample size
+          p: float, # p-value
+          z: bool = False, # True if p-value from z-statistic, False if t-statistic
+          method: str = "robust", # method for choice of 'b': "JAB", "min", "robust", "balanced"
+          upper: float = 10 # upper limit for range of realistic effect sizes
+         ) -> float: # Bayes factor in favor of H1
+  "Transforms a p-value into Jeffreys' approximate Bayes factor (BF)"
   method_dict = {"JAB": lambda n: 1/n, "min": lambda n: 2/n, "robust": lambda n: max(2/n, 1/np.sqrt(n))}
   if method == "balanced":
     integrand = lambda x: np.exp(-n * x**2 / 4)
@@ -499,17 +445,12 @@ def get_BF(n: int, p: float, z: bool = False, method: str = "robust", upper: flo
   return BF
 
 
-def get_alphaN(n: int, BF: float = 3, method: str = "robust", upper: float = 10) -> float:
-  """Set the alpha level based on sample size via Bayesian-Adaptive Alpha Adjustment.\n
-  | Arguments:
-  | :-
-  | n (int): Sample size.
-  | BF (float): Bayes factor you would like to match; default:3
-  | method (str): Method used for the choice of 'b'. Options are "JAB", "min", "robust", "balanced"; default:"robust"
-  | upper (float): The upper limit for the range of realistic effect sizes. Only relevant when method="balanced"; default:10\n
-  | Returns:
-  | :-
-  | float: Numeric alpha level required to achieve the desired level of evidence."""
+def get_alphaN(n: int, # sample size
+              BF: float = 3, # Bayes factor you would like to match
+              method: str = "robust", # method for choice of 'b': "JAB", "min", "robust", "balanced"
+              upper: float = 10 # upper limit for range of realistic effect sizes
+             ) -> float: # alpha level required to achieve desired evidence
+  "Set the alpha level based on sample size via Bayesian-Adaptive Alpha Adjustment"
   method_dict = {"JAB": lambda n: 1/n, "min": lambda n: 2/n, "robust": lambda n: max(2/n, 1/np.sqrt(n))}
   if method == "balanced":
     integrand = lambda x: np.exp(-n * x**2 / 4)
@@ -520,15 +461,10 @@ def get_alphaN(n: int, BF: float = 3, method: str = "robust", upper: float = 10)
   return alpha
 
 
-def pi0_tst(p_values: np.ndarray, alpha: float = 0.05) -> float:
-  """estimate the proportion of true null hypotheses in a set of p-values\n
-  | Arguments:
-  | :-
-  | p_values (array): array of p-values
-  | alpha (float): significance threshold for testing; default:0.05\n
-  | Returns:
-  | :-
-  | Returns an estimate of π0, the proportion of true null hypotheses in that dataset"""
+def pi0_tst(p_values: np.ndarray, # array of p-values
+           alpha: float = 0.05 # significance threshold for testing
+          ) -> float: # estimate of π0, proportion of true null hypotheses
+  "estimate the proportion of true null hypotheses in a set of p-values"
   alpha_prime = alpha / (1 + alpha)
   n = len(p_values)
   # Apply the BH procedure at level α'
@@ -545,17 +481,11 @@ def pi0_tst(p_values: np.ndarray, alpha: float = 0.05) -> float:
   return pi0_estimate
 
 
-def TST_grouped_benjamini_hochberg(identifiers_grouped: dict[str, list], p_values_grouped: dict[str, list[float]],
-                                   alpha: float) -> tuple[dict[str, float], dict[str, bool]]:
-  """perform the two-stage adaptive Benjamini-Hochberg procedure for multiple testing correction\n
-  | Arguments:
-  | :-
-  | identifiers_grouped (dict): dictionary of group : list of glycans
-  | p_values_grouped (dict): dictionary of group : list of p-values
-  | alpha (float): significance threshold for testing\n
-  | Returns:
-  | :-
-  | Returns dictionaries of glycan : corrected p-value and glycan : significant?"""
+def TST_grouped_benjamini_hochberg(identifiers_grouped: Dict[str, List], # dictionary of group : list of glycans
+                                 p_values_grouped: Dict[str, List[float]], # dictionary of group : list of p-values
+                                 alpha: float # significance threshold for testing
+                                ) -> Tuple[Dict[str, float], Dict[str, bool]]: # (glycan:corrected p-value dict, glycan:significant dict)
+  "perform the two-stage adaptive Benjamini-Hochberg procedure for multiple testing correction"
   # Initialize results
   adjusted_p_values = {}
   significance_dict = {}
@@ -588,19 +518,13 @@ def TST_grouped_benjamini_hochberg(identifiers_grouped: dict[str, list], p_value
   return adjusted_p_values, significance_dict
 
 
-def test_inter_vs_intra_group(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, glycans: list[str],
-                              grouped_glycans: dict[str, list[str]], paired: bool = False) -> tuple[float, float]:
-  """estimates intra- and inter-group correlation of a given grouping of glycans via a mixed-effects model\n
-  | Arguments:
-  | :-
-  | cohort_b (dataframe): dataframe of glycans as rows and samples as columns of the case samples
-  | cohort_a (dataframe): dataframe of glycans as rows and samples as columns of the control samples
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | grouped_glycans (dict): dictionary of type group : glycans
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | Returns floats for the intra-group and inter-group correlation"""
+def test_inter_vs_intra_group(cohort_b: pd.DataFrame, # dataframe of glycans as rows and samples as columns of case samples
+                            cohort_a: pd.DataFrame, # dataframe of glycans as rows and samples as columns of control samples
+                            glycans: List[str], # list of glycans in IUPAC-condensed nomenclature
+                            grouped_glycans: Dict[str, List[str]], # dictionary of type group : glycans
+                            paired: bool = False # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                           ) -> Tuple[float, float]: # (intra-group correlation, inter-group correlation)
+  "estimates intra- and inter-group correlation of a given grouping of glycans via a mixed-effects model"
   reverse_lookup = {k: v for v, l in grouped_glycans.items() for k in l}
   if paired:
     temp = pd.DataFrame(np.log2(abs((cohort_b.values + 1e-8) / (cohort_a.values + 1e-8))))
@@ -636,15 +560,10 @@ def test_inter_vs_intra_group(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, gl
   return icc, inter_group_corr
 
 
-def replace_outliers_with_IQR_bounds(full_row: pd.Series, cap_side: str = 'both') -> pd.Series:
-  """replaces outlier values with row median\n
-  | Arguments:
-  | :-
-  | full_row (pd.DataFrame row): row from a pandas dataframe, with all but possibly the first value being numerical
-  | cap_side (str): 'both', 'lower', or 'upper' to specify which side(s) to cap outliers on\n
-  | Returns:
-  | :-
-  | Returns row with replaced outliers"""
+def replace_outliers_with_IQR_bounds(full_row: pd.Series, # row from dataframe, with all but possibly first value numerical
+                                   cap_side: str = 'both' # which side(s) to cap outliers on: 'both', 'lower', or 'upper'
+                                  ) -> pd.Series: # row with replaced outliers
+  "replaces outlier values with row median"
   row = full_row.iloc[1:] if isinstance(full_row.iloc[0], str) else full_row
   # Calculate Q1, Q3, and IQR for each row
   Q1 = row.quantile(0.25)
@@ -669,15 +588,10 @@ def replace_outliers_with_IQR_bounds(full_row: pd.Series, cap_side: str = 'both'
   return full_row
 
 
-def replace_outliers_winsorization(full_row: pd.Series, cap_side: str = 'both') -> pd.Series:
-  """Replaces outlier values using Winsorization.\n
-  | Arguments:
-  | :-
-  | full_row (pd.DataFrame row): row from a pandas dataframe, with all but possibly the first value being numerical
-  | cap_side (str): 'both', 'lower', or 'upper' to specify which side(s) to cap outliers on\n
-  | Returns:
-  | :-
-  | Returns row with outliers replaced by Winsorization."""
+def replace_outliers_winsorization(full_row: pd.Series, # row from dataframe, with all but possibly first value numerical
+                                 cap_side: str = 'both' # which side(s) to cap outliers on: 'both', 'lower', or 'upper'
+                                ) -> pd.Series: # row with outliers replaced by Winsorization
+  "Replaces outlier values using Winsorization"
   row = full_row.iloc[1:] if isinstance(full_row.iloc[0], str) else full_row
   # Apply Winsorization - limits set to match typical IQR outlier detection
   nan_placeholder = row.min() - 1
@@ -700,8 +614,11 @@ def replace_outliers_winsorization(full_row: pd.Series, cap_side: str = 'both') 
   return full_row
 
 
-def hotellings_t2(group1: np.ndarray, group2: np.ndarray, paired: bool = False) -> tuple[float, float]:
-  """Hotelling's T^2 test (the t-test for multivariate comparisons)\n"""
+def hotellings_t2(group1: np.ndarray, # comparison group containing numerical data
+                 group2: np.ndarray, # comparison group containing numerical data
+                 paired: bool = False # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                ) -> Tuple[float, float]: # (F statistic, p-value)
+  "Hotelling's T^2 test (the t-test for multivariate comparisons)"
   if paired:
     assert group1.shape == group2.shape, "For paired samples, the size of group1 and group2 should be the same"
     group1 -= group2
@@ -735,49 +652,44 @@ def hotellings_t2(group1: np.ndarray, group2: np.ndarray, paired: bool = False) 
   return F, p_value
 
 
-def sequence_richness(counts: np.ndarray) -> int:
+def sequence_richness(counts: np.ndarray # array of counts per feature
+                    ) -> int: # number of non-zero features
+  "counts number of features with non-zero abundance"
   return (counts != 0).sum()
 
 
-def shannon_diversity_index(counts: np.ndarray) -> float:
+def shannon_diversity_index(counts: np.ndarray # array of counts
+                         ) -> float: # Shannon diversity index value
+  "calculates Shannon diversity index"
   proportions = counts / counts.sum()
   return entropy(proportions)
 
 
-def simpson_diversity_index(counts: np.ndarray) -> float:
+def simpson_diversity_index(counts: np.ndarray # array of counts
+                         ) -> float: # Simpson diversity index value
+  "calculates Simpson diversity index"
   proportions = counts / counts.sum()
   return 1 - np.sum(proportions**2)
 
 
-def get_equivalence_test(row_a: np.ndarray, row_b: np.ndarray, paired: bool = False) -> float:
-  """performs an equivalence test (two one-sided t-tests) to test whether differences between group means are considered practically equivalent\n
-  | Arguments:
-  | :-
-  | row_a (array-like): basically a row of the control samples for one glycan/motif
-  | row_b (array-like): basically a row of the case samples for one glycan/motif
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | Returns a p-value of whether the two group means can be considered equivalent"""
+def get_equivalence_test(row_a: np.ndarray, # array of control samples for one glycan/motif
+                        row_b: np.ndarray, # array of case samples for one glycan/motif
+                        paired: bool = False # whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient)
+                       ) -> float: # p-value for equivalence test
+  "performs equivalence test (two one-sided t-tests) to test whether differences between group means are considered practically equivalent"
   pooled_std = np.sqrt(((len(row_a) - 1) * np.var(row_a, ddof = 1) + (len(row_b) - 1) * np.var(row_b, ddof = 1)) / (len(row_a) + len(row_b) - 2))
   delta = 0.2 * pooled_std
   low, up = -delta, delta
   return ttost_paired(row_a, row_b, low, up)[0] if paired else ttost_ind(row_a, row_b, low, up)[0]
 
 
-def clr_transformation(df: pd.DataFrame, group1: list[str | int], group2: list[str | int],
-                       gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """performs the Center Log-Ratio (CLR) Transformation with scale model adjustment\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing features in rows and samples in columns
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | gamma (float): the degree of uncertainty that the CLR assumption holds; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | Returns a dataframe that is CLR-transformed with scale model adjustment"""
+def clr_transformation(df: pd.DataFrame, # dataframe with features as rows and samples as columns
+                      group1: List[Union[str, int]], # column indices/names for first group of samples, usually control
+                      group2: List[Union[str, int]], # column indices/names for second group of samples
+                      gamma: float = 0.1, # degree of uncertainty that CLR assumption holds
+                      custom_scale: Union[float, Dict] = 0 # ratio total signal group2/group1 for scale model (or group_idx:mean/min dict for multivariate)
+                     ) -> pd.DataFrame: # CLR-transformed dataframe
+  "performs the Center Log-Ratio (CLR) Transformation with scale model adjustment"
   geometric_mean = gmean(df.replace(0, np.nan), axis = 0, nan_policy = 'omit')
   clr_adjusted = np.zeros_like(df.values)
   if gamma and not isinstance(custom_scale, dict):
@@ -802,17 +714,11 @@ def clr_transformation(df: pd.DataFrame, group1: list[str | int], group2: list[s
   return pd.DataFrame(clr_adjusted, index = df.index, columns = df.columns)
 
 
-def anosim(df: pd.DataFrame, group_labels_in: list[str], permutations: int = 999) -> tuple[float, float]:
-  """Performs analysis of similarity statistical test\n
-  | Arguments:
-  | :-
-  | df (dataframe): square distance matrix
-  | group_labels_in (list): list of group membership for each sample
-  | permutations (int): number of permutations to perform in ANOSIM statistical test; default:999\n
-  | Returns:
-  | :-
-  | (i) ANOSIM R statistic - ranges between -1 to 1.
-  | (ii) p-value of the R statistic"""
+def anosim(df: pd.DataFrame, # square distance matrix
+          group_labels_in: List[str], # list of group membership for each sample
+          permutations: int = 999 # number of permutations to perform in ANOSIM test
+         ) -> Tuple[float, float]: # (ANOSIM R statistic [-1 to 1], p-value)
+  "Performs analysis of similarity (ANOSIM) statistical test"
   group_labels = copy.deepcopy(group_labels_in)
   n = df.shape[0]
   condensed_dist = df.values[np.tril_indices(n, k = -1)]
@@ -840,15 +746,10 @@ def anosim(df: pd.DataFrame, group_labels_in: list[str], permutations: int = 999
   return R, p_value
 
 
-def alpha_biodiversity_stats(df: pd.DataFrame, group_labels: list[str]) -> tuple[float, float] | None:
-  """Performs an ANOVA on the respective alpha diversity distance\n
-  | Arguments:
-  | :-
-  | df (dataframe): square distance matrix
-  | group_labels (list): list of group membership for each sample\n
-  | Returns:
-  | :-
-  | F statistic and p-value"""
+def alpha_biodiversity_stats(df: pd.DataFrame, # square distance matrix
+                           group_labels: List[str] # list of group membership for each sample
+                          ) -> Optional[Tuple[float, float]]: # F statistic and p-value if groups have >1 sample, None otherwise
+  "Performs an ANOVA on the respective alpha diversity distance"
   group_counts = Counter(group_labels)
   if all(count > 1 for count in group_counts.values()):
     stat_outputs = pd.DataFrame({'group': group_labels, 'diversity': df.squeeze()})
@@ -857,15 +758,10 @@ def alpha_biodiversity_stats(df: pd.DataFrame, group_labels: list[str]) -> tuple
     return stats
 
 
-def calculate_permanova_stat(df: pd.DataFrame, group_labels: list[str]) -> float:
-  """Performs multivariate analysis of variance\n
-  | Arguments:
-  | :-
-  | df (dataframe): square distance matrix
-  | group_labels (list): list of group membership for each sample\n
-  | Returns:
-  | :-
-  | F statistic - higher means effect more likely."""
+def calculate_permanova_stat(df: pd.DataFrame, # square distance matrix
+                           group_labels: List[str] # list of group membership for each sample
+                          ) -> float: # F statistic - higher means effect more likely
+  "Performs multivariate analysis of variance"
   unique_groups = np.unique(group_labels)
   n = len(group_labels)
   # Between-group and within-group sums of squares
@@ -883,17 +779,11 @@ def calculate_permanova_stat(df: pd.DataFrame, group_labels: list[str]) -> float
   return f_stat
 
 
-def permanova_with_permutation(df: pd.DataFrame, group_labels: list[str], permutations: int = 999) -> tuple[float, float]:
-  """Performs permutational multivariate analysis of variance\n
-  | Arguments:
-  | :-
-  | df (dataframe): square distance matrix
-  | group_labels (list): list of group membership for each sample
-  | permutations (int): number of permutations to perform in PERMANOVA statistical test; default:999\n
-  | Returns:
-  | :-
-  | (i) F statistic - higher means effect more likely.
-  | (ii) p-value of the F statistic"""
+def permanova_with_permutation(df: pd.DataFrame, # square distance matrix
+                             group_labels: List[str], # list of group membership for each sample
+                             permutations: int = 999 # number of permutations for test
+                            ) -> Tuple[float, float]: # (F statistic, p-value)
+  "Performs permutational multivariate analysis of variance (PERMANOVA)"
   observed_f = calculate_permanova_stat(df, group_labels)
   permuted_fs = np.zeros(permutations)
   for i in range(permutations):
@@ -903,20 +793,14 @@ def permanova_with_permutation(df: pd.DataFrame, group_labels: list[str], permut
   return observed_f, p_value
 
 
-def alr_transformation(df: pd.DataFrame, reference_component_index: int, group1: list[str | int], group2: list[str | int],
-                       gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """Given a reference feature, performs additive log-ratio transformation (ALR) on the data\n
-  | Arguments:
-  | :-
-  | df (dataframe): log2-transformed dataframe with features as rows and samples as columns
-  | reference_component_index (int): row index of feature to be used as reference
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | gamma (float): the degree of uncertainty that the CLR assumption holds; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | ALR-transformed dataframe"""
+def alr_transformation(df: pd.DataFrame, # dataframe with features as rows and samples as columns
+                      reference_component_index: int, # row index of feature to be used as reference
+                      group1: List[Union[str, int]], # column indices/names for first group of samples, usually control
+                      group2: List[Union[str, int]], # column indices/names for second group of samples
+                      gamma: float = 0.1, # degree of uncertainty that CLR assumption holds
+                      custom_scale: Union[float, Dict] = 0 # ratio total signal group2/group1 for scale model (or group_idx:mean/min dict for multivariate)
+                     ) -> pd.DataFrame: # ALR-transformed dataframe
+  "Given a reference feature, performs additive log-ratio transformation (ALR) on the data"
   reference_values = df.iloc[reference_component_index, :]
   alr_transformed = np.zeros_like(df.values)
   group1i = [df.columns.get_loc(c) for c in group1]
@@ -941,19 +825,13 @@ def alr_transformation(df: pd.DataFrame, reference_component_index: int, group1:
   return alr_transformed
 
 
-def get_procrustes_scores(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], paired: bool = False,
-                          custom_scale: float | dict = 0) -> tuple[list[float], list[float], list[float]]:
-  """For each feature, estimates it value as ALR reference component\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with features as rows and samples as columns
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | List of Procrustes scores (Procrustes correlation * inverse of feature variance)"""
+def get_procrustes_scores(df: pd.DataFrame, # dataframe with features as rows and samples as columns
+                         group1: List[Union[str, int]], # column indices/names for first group of samples, usually control
+                         group2: List[Union[str, int]], # column indices/names for second group of samples
+                         paired: bool = False, # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                         custom_scale: Union[float, Dict] = 0 # ratio total signal group2/group1 for scale model (or group_idx:mean/min dict)
+                        ) -> Tuple[List[float], List[float], List[float]]: # (Procrustes scores, correlations, variances)
+  "For each feature, estimates its value as ALR reference component"
   if isinstance(group1[0], int):
     group1 = [df.columns.tolist()[k] for k in group1]
     group2 = [df.columns.tolist()[k] for k in group2]
@@ -975,20 +853,14 @@ def get_procrustes_scores(df: pd.DataFrame, group1: list[str | int], group2: lis
   return [a * (1/b) for a, b in zip(procrustes_corr, variances)], procrustes_corr, variances
 
 
-def get_additive_logratio_transformation(df: pd.DataFrame, group1: list[str | int], group2: list[str | int],
-                                         paired: bool = False, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """Identifies ALR reference component and transforms data according to ALR\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with features as rows and samples as columns
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | gamma (float): the degree of uncertainty that the CLR assumption holds; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | ALR-transformed dataframe"""
+def get_additive_logratio_transformation(df: pd.DataFrame, # dataframe with features as rows and samples as columns
+                                       group1: List[Union[str, int]], # column indices/names for first group of samples
+                                       group2: List[Union[str, int]], # column indices/names for second group of samples
+                                       paired: bool = False, # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                                       gamma: float = 0.1, # degree of uncertainty that CLR assumption holds
+                                       custom_scale: Union[float, Dict] = 0 # ratio total signal group2/group1 for scale model
+                                      ) -> pd.DataFrame: # ALR-transformed dataframe
+  "Identifies ALR reference component and transforms data according to ALR"
   scores, procrustes_corr, variances = get_procrustes_scores(df, group1, group2, paired = paired, custom_scale = custom_scale)
   ref_component = np.argmax(scores)
   ref_component_string = df.iloc[:, 0].values[ref_component]
@@ -1004,17 +876,11 @@ def get_additive_logratio_transformation(df: pd.DataFrame, group1: list[str | in
   return alr
 
 
-def correct_multiple_testing(pvals: list[float] | np.ndarray, alpha: float, correction_method: str = "two-stage") -> tuple[list[float], list[bool]]:
-  """Corrects p-values for multiple testing, by default with the two-stage Benjamini-Hochberg procedure\n
-  | Arguments:
-  | :-
-  | pvals (list): list of raw p-values
-  | alpha (float): p-value threshold for statistical significance
-  | correction_method (string): whether to use "two-stage" or "one-stage" Benjamini-Hochberg for correction; default:"two-stage"\n
-  | Returns:
-  | :-
-  | (i) list of corrected p-values
-  | (ii) list of True/False of whether corrected p-value reaches statistical significance"""
+def correct_multiple_testing(pvals: Union[List[float], np.ndarray], # list of raw p-values
+                           alpha: float, # p-value threshold for statistical significance
+                           correction_method: str = "two-stage" # "two-stage" or "one-stage" Benjamini-Hochberg
+                          ) -> Tuple[List[float], List[bool]]: # (corrected p-values, significance True/False)
+  "Corrects p-values for multiple testing, by default with the two-stage Benjamini-Hochberg procedure"
   if not isinstance(pvals, list):
     pvals = pvals.tolist()
   corrpvals = multipletests(pvals, method = 'fdr_tsbh' if correction_method == "two-stage" else 'fdr_bh')[1]
@@ -1029,15 +895,10 @@ def correct_multiple_testing(pvals: list[float] | np.ndarray, alpha: float, corr
   return corrpvals, significance
 
 
-def omega_squared(row: pd.Series | np.ndarray, groups: list[str]) -> float:
-  """Calculates Omega squared, as an effect size in an ANOVA setting\n
-  | Arguments:
-  | :-
-  | row (pd.Series or array-like): values for one feature
-  | groups (list): list indicating group membership with indices per column\n
-  | Returns:
-  | :-
-  | Returns effect size as omega squared (float)"""
+def omega_squared(row: Union[pd.Series, np.ndarray], # values for one feature
+                 groups: List[str] # list indicating group membership with indices per column
+                ) -> float: # effect size as omega squared
+  "Calculates Omega squared, as an effect size in an ANOVA setting"
   long_df = pd.DataFrame({'value': row, 'group': groups})
   model = ols('value ~ C(group)', data = long_df).fit()
   anova_results = anova_lm(model, typ = 2)
@@ -1046,20 +907,11 @@ def omega_squared(row: pd.Series | np.ndarray, groups: list[str]) -> float:
   return omega_squared
 
 
-def get_glycoform_diff(df_res: pd.DataFrame, alpha: float = 0.05, level: str = 'peptide') -> pd.DataFrame:
-  """Calculates differential expression of glycoforms of either a peptide or a whole protein\n
-  | Arguments:
-  | :-
-  | df_res (pd.DataFrame): result from .motif.analysis.get_differential_expression
-  | alpha (float): significance threshold for testing; default:0.05
-  | level (string): whether to analyze glycoform differential expression at the level of 'peptide' or 'protein'; default:'peptide'\n
-  | Returns:
-  | :-
-  | Returns a dataframe with:
-  | (i) Differentially expressed glycopeptides/glycoproteins
-  | (ii) Corrected p-values (Welch's t-test with two-stage Benjamini-Hochberg correction aggregated with Fisher’s Combined Probability Test) for difference in mean
-  | (iii) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold
-  | (iv) Effect size as the average Cohen's d across glycoforms"""
+def get_glycoform_diff(df_res: pd.DataFrame, # result from .motif.analysis.get_differential_expression
+                      alpha: float = 0.05, # significance threshold for testing
+                      level: str = 'peptide' # analyze at 'peptide' or 'protein' level
+                     ) -> pd.DataFrame: # df with differential expression results, p-vals (Fisher’s Combined Probability Test), significance, effect sizes (Cohen's d)
+  "Calculates differential expression of glycoforms from either a peptide or a whole protein"
   label_col = 'Glycosite' if 'Glycosite' in df_res.columns else 'Glycan'
   if level == 'protein':
     df_res[label_col] = [k.split('_')[0] for k in df_res[label_col]]
@@ -1072,15 +924,10 @@ def get_glycoform_diff(df_res: pd.DataFrame, alpha: float = 0.05, level: str = '
   return df_out.sort_values(by = 'corr p-val')
 
 
-def get_glm(group: pd.DataFrame, glycan_features: list[str] = ['H', 'N', 'A', 'F', 'G']) -> tuple[str | str, list[str]]:
-  """given glycoform data from a glycosite, constructs & fits a GLM formula for main+interaction effects of explaining glycoform abundance\n
-  | Arguments:
-  | :-
-  | group (dataframe): longform data of glycoform abundances for a particular glycosite
-  | glycan_features (list): list of extracted glycan features to consider as variables; default:['H', 'N', 'A', 'F', 'G']\n
-  | Returns:
-  | :-
-  | Returns fitted GLM (or string with failure message if unsuccessful) and a list of the variables that it contains"""
+def get_glm(group: pd.DataFrame, # longform data of glycoform abundances for a glycosite
+           glycan_features: List[str] = ['H', 'N', 'A', 'F', 'G'] # extracted glycan features to consider as variables
+          ) -> Tuple[Union[str, str], List[str]]: # (fitted GLM or failure message, list of variables)
+  "given glycoform data from a glycosite, constructs & fits a GLM formula for main+interaction effects"
   retained_vars = [c for c in glycan_features if c in group.columns and max(group[c]) > 0]
   if not retained_vars:
     return ("No variables retained", [])
@@ -1098,18 +945,11 @@ def get_glm(group: pd.DataFrame, glycan_features: list[str] = ['H', 'N', 'A', 'F
     return (f"GLM fitting failed: {str(e)}", [])
 
 
-def process_glm_results(df: pd.DataFrame, alpha: float, glycan_features: list[str]) -> pd.DataFrame:
-  """tests for interaction effects of glycan features and the condition on glycoform abundance via a GLM\n
-  | Arguments:
-  | :-
-  | df (dataframe): CLR-transformed glycoproteomics data (processed grouped by site), rows glycoforms, columns samples
-  | glycan_features (list): list of extracted glycan features to consider as variables\n
-  | Returns:
-  | :-
-  | (for each condition/interaction feature)
-  | (i) Regression coefficient from the GLM (indicating direction of change in the treatment condition)
-  | (ii) Corrected p-values (two-tailed t-test with two-stage Benjamini-Hochberg correction) for testing the coefficient against zero
-  | (iii) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold"""
+def process_glm_results(df: pd.DataFrame, # CLR-transformed glycoproteomics data, rows glycoforms, columns samples
+                       alpha: float, # significance threshold
+                       glycan_features: List[str] # extracted glycan features to consider as variables
+                      ) -> pd.DataFrame: # regression coefficients, p-values, and significance for each condition/interaction
+  "tests for interaction effects of glycan features and the condition on glycoform abundance via a GLM"
   results = df.groupby('Glycosite').apply(get_glm, glycan_features = glycan_features)
   all_retained_vars = set()
   for _, retained_vars in results:
@@ -1130,18 +970,12 @@ def process_glm_results(df: pd.DataFrame, alpha: float, glycan_features: list[st
   return df_out.sort_values(by = 'Condition_corr_pval')
 
 
-def partial_corr(x: np.ndarray, y: np.ndarray, controls: np.ndarray, motifs: bool = False) -> tuple[float, float]:
-  """Compute regularized partial correlation of x and y, controlling for multiple other variables in controls\n
-  | Arguments:
-  | :-
-  | x (array-like): typically the values from a column or row
-  | y (array-like): typically the values from a column or row
-  | controls (array-like): variables that are correlated with x or y
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False\n
-  | Returns:
-  | :-
-  | float: regularized partial correlation coefficient.
-  | float: p-value associated with the Spearman correlation of residuals.\n"""
+def partial_corr(x: np.ndarray, # typically values from a column or row
+                y: np.ndarray, # typically values from a column or row
+                controls: np.ndarray, # variables correlated with x or y
+                motifs: bool = False # whether to analyze full sequences or motifs
+               ) -> Tuple[float, float]: # (regularized partial correlation coefficient, p-value from Spearman correlation of residuals)
+  "Compute regularized partial correlation of x and y, controlling for multiple other variables in controls"
   # Fit regression models
   alpha = 0.1 if motifs else 0.25
   beta_x = Ridge(alpha = alpha).fit(controls, x).coef_
@@ -1154,20 +988,14 @@ def partial_corr(x: np.ndarray, y: np.ndarray, controls: np.ndarray, motifs: boo
   return corr, pval
 
 
-def estimate_technical_variance(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], num_instances: int = 128,
-                                gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """Monte Carlo sampling from the Dirichlet distribution with relative abundances as concentration, followed by CLR transformation.\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | num_instances (int): Number of Monte Carlo instances to sample; default:128
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | Returns a transformed dataframe of shape (features, samples*num_instances) with CLR-transformed Monte Carlo Dirichlet instances."""
+def estimate_technical_variance(df: pd.DataFrame, # dataframe with glycans in first col and abundances in subsequent cols
+                              group1: List[Union[str, int]], # column indices/names for first group of samples
+                              group2: List[Union[str, int]], # column indices/names for second group of samples
+                              num_instances: int = 128, # number of Monte Carlo instances to sample
+                              gamma: float = 0.1, # uncertainty parameter for CLR transformation scale
+                              custom_scale: Union[float, Dict] = 0 # ratio total signal group2/group1 for scale model
+                             ) -> pd.DataFrame: # transformed df (features, samples*num_instances) with CLR-transformed Monte Carlo instances
+  "Monte Carlo sampling from Dirichlet distribution with relative abundances as concentration, followed by CLR transformation"
   df = df.apply(lambda col: (col / col.sum())*5000, axis = 0)
   features, samples = df.shape
   transformed_data = np.zeros((features, samples, num_instances))
@@ -1184,20 +1012,12 @@ def estimate_technical_variance(df: pd.DataFrame, group1: list[str | int], group
   return transformed_df
 
 
-def perform_tests_monte_carlo(group_a: pd.DataFrame, group_b: pd.DataFrame, num_instances: int = 128,
-                              paired: bool = False) -> tuple[list[float], list[float], list[float]]:
-  """Perform tests on each Monte Carlo instance, apply Benjamini-Hochberg correction, and calculate effect sizes and variances.\n
-  | Arguments:
-  | :-
-  | group_a (dataframe): rows as featureas and columns as sample instances from one condition
-  | group_b (dataframe): rows as featureas and columns as sample instances from one condition
-  | num_instances (int): Number of Monte Carlo instances to sample; default:128
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False\n
-  | Returns:
-  | :-
-  | (i) list of uncorrected p-values
-  | (ii) list of corrected p-values (two-stage Benjamini-Hochberg)
-  | (ii) list of effect sizes (Cohen's d)"""
+def perform_tests_monte_carlo(group_a: pd.DataFrame, # rows as features, columns as sample instances from one condition
+                            group_b: pd.DataFrame, # rows as features, columns as sample instances from one condition
+                            num_instances: int = 128, # number of Monte Carlo instances to sample
+                            paired: bool = False # whether samples are paired (e.g. tumor & tumor-adjacent tissue)
+                           ) -> Tuple[List[float], List[float], List[float]]: # (uncorrected p-vals, corrected p-vals, effect sizes)
+  "Perform tests on each Monte Carlo instance, apply Benjamini-Hochberg correction, calculate effect sizes"
   num_features, _ = group_a.shape
   avg_uncorrected_p_values, avg_corrected_p_values, avg_effect_sizes = np.zeros(num_features), np.zeros(num_features), np.zeros(num_features)
   for instance in range(num_instances):

--- a/glycowork/glycan_data/stats.py
+++ b/glycowork/glycan_data/stats.py
@@ -23,21 +23,21 @@ rng = np.random.default_rng(42)
 np.random.seed(0)
 
 
-def fast_two_sum(a, b):
+def fast_two_sum(a: int | float, b: int | float) -> list[int]:
   """Assume abs(a) >= abs(b)"""
   x = int(a) + int(b)
   y = b - (x - int(a))
   return [x] if y == 0 else [x, y]
 
 
-def two_sum(a, b):
+def two_sum(a: int | float, b: int | float) -> list[int]:
   """For unknown order of a and b"""
   x = int(a) + int(b)
   y = (a - (x - int(b))) + (b - (x - int(a)))
   return [x] if y == 0 else [x, y]
 
 
-def expansion_sum(*args):
+def expansion_sum(*args: int | float) -> int | list[int | float]:
   """For the expansion sum of floating points"""
   g = sorted(args, reverse = True)
   q, *h = fast_two_sum(np.array(g[0]), np.array(g[1]))
@@ -49,7 +49,7 @@ def expansion_sum(*args):
   return [h, q] if h else q
 
 
-def hlm(z):
+def hlm(z: np.ndarray | list[float]) -> float:
   """Hodges-Lehmann estimator of the median"""
   z = np.array(z)
   zz = np.add.outer(z, z)
@@ -57,7 +57,7 @@ def hlm(z):
   return np.median(zz) / 2
 
 
-def update_cf_for_m_n(m, n, MM, cf):
+def update_cf_for_m_n(m: int, n: int, MM: int, cf: list[float]) -> None:
   """Constructs cumulative frequency table for experimental parameters defined in the function 'jtkinit'"""
   P = min(m + n, MM)
   for t_temp in range(n + 1, P + 1):  # Zero-based offset t_temp
@@ -69,7 +69,7 @@ def update_cf_for_m_n(m, n, MM, cf):
       cf[u] = expansion_sum(cf[u], cf[u - s])  # Shewchuk algorithm
 
 
-def cohen_d(x, y, paired = False):
+def cohen_d(x: np.ndarray | list[float], y: np.ndarray | list[float], paired: bool = False) -> tuple[float, float]:
   """calculates effect size between two groups\n
   | Arguments:
   | :-
@@ -99,7 +99,7 @@ def cohen_d(x, y, paired = False):
   return d, var_d
 
 
-def mahalanobis_distance(x, y, paired = False):
+def mahalanobis_distance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFrame, paired: bool = False) -> float:
   """calculates effect size between two groups in a multivariate comparison\n
   | Arguments:
   | :-
@@ -123,7 +123,7 @@ def mahalanobis_distance(x, y, paired = False):
   return mahalanobis_d[0][0]
 
 
-def mahalanobis_variance(x, y, paired = False):
+def mahalanobis_variance(x: np.ndarray | pd.DataFrame, y: np.ndarray | pd.DataFrame, paired: bool = False) -> float:
   """Estimates variance of Mahalanobis distance via bootstrapping\n
   | Arguments:
   | :-
@@ -152,7 +152,7 @@ def mahalanobis_variance(x, y, paired = False):
   return np.var(bootstrap_samples)
 
 
-def variance_stabilization(data, groups = None):
+def variance_stabilization(data: pd.DataFrame, groups: list[list[str]] | None = None) -> pd.DataFrame:
   """Variance stabilization normalization\n
   | Arguments:
   | :-
@@ -183,7 +183,8 @@ class MissForest:
 
   n_iter : int
   Determines the number of iterations for the imputation process."""
-  def __init__(self, regressor = RandomForestRegressor(n_jobs = -1), max_iter = 5, tol = 1e-5):
+  def __init__(self, regressor: RandomForestRegressor = RandomForestRegressor(n_jobs = -1),
+               max_iter: int = 5, tol: float = 1e-5) -> None:
     self.regressor = regressor
     self.max_iter = max_iter
     self.tol = tol
@@ -219,7 +220,7 @@ class MissForest:
     return X_transform
 
 
-def impute_and_normalize(df, groups, impute = True, min_samples = 0.1):
+def impute_and_normalize(df: pd.DataFrame, groups: list[list[str]], impute: bool = True, min_samples: float = 0.1) -> pd.DataFrame:
     """given a dataframe, discards rows with too many missings, imputes the rest, and normalizes\n
     | Arguments:
     | :-
@@ -256,7 +257,7 @@ def impute_and_normalize(df, groups, impute = True, min_samples = 0.1):
     return df
 
 
-def variance_based_filtering(df, min_feature_variance = 0.02):
+def variance_based_filtering(df: pd.DataFrame, min_feature_variance: float = 0.02) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Variance-based filtering of features\n
     | Arguments:
     | :-
@@ -272,7 +273,7 @@ def variance_based_filtering(df, min_feature_variance = 0.02):
     return filtered_df, discarded_df
 
 
-def jtkdist(timepoints, param_dic, reps = 1, normal = False):
+def jtkdist(timepoints: int | np.ndarray, param_dic: dict, reps: int = 1, normal: bool = False) -> dict:
   """Precalculates all possible JT test statistic permutation probabilities for reference later, speeding up the
   | analysis. Calculates the exact null distribution using the Harding algorithm.\n
   | Arguments:
@@ -321,7 +322,7 @@ def jtkdist(timepoints, param_dic, reps = 1, normal = False):
   return param_dic
 
 
-def jtkinit(periods, param_dic, interval = 1, replicates = 1):
+def jtkinit(periods: list[int], param_dic: dict, interval: int = 1, replicates: int = 1) -> dict:
   """Defines the parameters of the simulated sine waves for reference later.\n
   | Each molecular species within the analysis is matched to the optimal wave defined here, and the parameters
   | describing that wave are attributed to the molecular species.\n
@@ -390,7 +391,7 @@ def jtkinit(periods, param_dic, interval = 1, replicates = 1):
   return param_dic
 
 
-def jtkstat(z, param_dic):
+def jtkstat(z: pd.DataFrame, param_dic: dict) -> dict:
   """Determines the JTK statistic and p-values for all model phases, compared to expression data.\n
   | Arguments:
   | :-
@@ -423,7 +424,7 @@ def jtkstat(z, param_dic):
   return param_dic
 
 
-def jtkx(z, param_dic, ampci = False):
+def jtkx(z: pd.DataFrame, param_dic: dict, ampci: bool = False) -> pd.Series:
   """Deployment of jtkstat for repeated use, and parameter extraction\n
   | Arguments:
   | :-
@@ -476,7 +477,7 @@ def jtkx(z, param_dic, ampci = False):
   return pd.Series([JTK_ADJP, JTK_PERIOD, JTK_LAG, JTK_AMP])
 
 
-def get_BF(n, p, z = False, method = "robust", upper = 10):
+def get_BF(n: int, p: float, z: bool = False, method: str = "robust", upper: float = 10) -> float:
   """Transforms a p-value into Jeffreys' approximate Bayes factor (BF)\n
   | Arguments:
   | :-
@@ -498,7 +499,7 @@ def get_BF(n, p, z = False, method = "robust", upper = 10):
   return BF
 
 
-def get_alphaN(n, BF = 3, method = "robust", upper = 10):
+def get_alphaN(n: int, BF: float = 3, method: str = "robust", upper: float = 10) -> float:
   """Set the alpha level based on sample size via Bayesian-Adaptive Alpha Adjustment.\n
   | Arguments:
   | :-
@@ -519,7 +520,7 @@ def get_alphaN(n, BF = 3, method = "robust", upper = 10):
   return alpha
 
 
-def pi0_tst(p_values, alpha = 0.05):
+def pi0_tst(p_values: np.ndarray, alpha: float = 0.05) -> float:
   """estimate the proportion of true null hypotheses in a set of p-values\n
   | Arguments:
   | :-
@@ -544,7 +545,8 @@ def pi0_tst(p_values, alpha = 0.05):
   return pi0_estimate
 
 
-def TST_grouped_benjamini_hochberg(identifiers_grouped, p_values_grouped, alpha):
+def TST_grouped_benjamini_hochberg(identifiers_grouped: dict[str, list], p_values_grouped: dict[str, list[float]],
+                                   alpha: float) -> tuple[dict[str, float], dict[str, bool]]:
   """perform the two-stage adaptive Benjamini-Hochberg procedure for multiple testing correction\n
   | Arguments:
   | :-
@@ -586,7 +588,8 @@ def TST_grouped_benjamini_hochberg(identifiers_grouped, p_values_grouped, alpha)
   return adjusted_p_values, significance_dict
 
 
-def test_inter_vs_intra_group(cohort_b, cohort_a, glycans, grouped_glycans, paired = False):
+def test_inter_vs_intra_group(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, glycans: list[str],
+                              grouped_glycans: dict[str, list[str]], paired: bool = False) -> tuple[float, float]:
   """estimates intra- and inter-group correlation of a given grouping of glycans via a mixed-effects model\n
   | Arguments:
   | :-
@@ -633,7 +636,7 @@ def test_inter_vs_intra_group(cohort_b, cohort_a, glycans, grouped_glycans, pair
   return icc, inter_group_corr
 
 
-def replace_outliers_with_IQR_bounds(full_row, cap_side = 'both'):
+def replace_outliers_with_IQR_bounds(full_row: pd.Series, cap_side: str = 'both') -> pd.Series:
   """replaces outlier values with row median\n
   | Arguments:
   | :-
@@ -666,7 +669,7 @@ def replace_outliers_with_IQR_bounds(full_row, cap_side = 'both'):
   return full_row
 
 
-def replace_outliers_winsorization(full_row, cap_side = 'both'):
+def replace_outliers_winsorization(full_row: pd.Series, cap_side: str = 'both') -> pd.Series:
   """Replaces outlier values using Winsorization.\n
   | Arguments:
   | :-
@@ -697,7 +700,7 @@ def replace_outliers_winsorization(full_row, cap_side = 'both'):
   return full_row
 
 
-def hotellings_t2(group1, group2, paired = False):
+def hotellings_t2(group1: np.ndarray, group2: np.ndarray, paired: bool = False) -> tuple[float, float]:
   """Hotelling's T^2 test (the t-test for multivariate comparisons)\n"""
   if paired:
     assert group1.shape == group2.shape, "For paired samples, the size of group1 and group2 should be the same"
@@ -732,21 +735,21 @@ def hotellings_t2(group1, group2, paired = False):
   return F, p_value
 
 
-def sequence_richness(counts):
+def sequence_richness(counts: np.ndarray) -> int:
   return (counts != 0).sum()
 
 
-def shannon_diversity_index(counts):
+def shannon_diversity_index(counts: np.ndarray) -> float:
   proportions = counts / counts.sum()
   return entropy(proportions)
 
 
-def simpson_diversity_index(counts):
+def simpson_diversity_index(counts: np.ndarray) -> float:
   proportions = counts / counts.sum()
   return 1 - np.sum(proportions**2)
 
 
-def get_equivalence_test(row_a, row_b, paired = False):
+def get_equivalence_test(row_a: np.ndarray, row_b: np.ndarray, paired: bool = False) -> float:
   """performs an equivalence test (two one-sided t-tests) to test whether differences between group means are considered practically equivalent\n
   | Arguments:
   | :-
@@ -762,7 +765,8 @@ def get_equivalence_test(row_a, row_b, paired = False):
   return ttost_paired(row_a, row_b, low, up)[0] if paired else ttost_ind(row_a, row_b, low, up)[0]
 
 
-def clr_transformation(df, group1, group2, gamma = 0.1, custom_scale = 0):
+def clr_transformation(df: pd.DataFrame, group1: list[str | int], group2: list[str | int],
+                       gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """performs the Center Log-Ratio (CLR) Transformation with scale model adjustment\n
   | Arguments:
   | :-
@@ -798,7 +802,7 @@ def clr_transformation(df, group1, group2, gamma = 0.1, custom_scale = 0):
   return pd.DataFrame(clr_adjusted, index = df.index, columns = df.columns)
 
 
-def anosim(df, group_labels_in, permutations = 999):
+def anosim(df: pd.DataFrame, group_labels_in: list[str], permutations: int = 999) -> tuple[float, float]:
   """Performs analysis of similarity statistical test\n
   | Arguments:
   | :-
@@ -836,7 +840,7 @@ def anosim(df, group_labels_in, permutations = 999):
   return R, p_value
 
 
-def alpha_biodiversity_stats(df, group_labels):
+def alpha_biodiversity_stats(df: pd.DataFrame, group_labels: list[str]) -> tuple[float, float] | None:
   """Performs an ANOVA on the respective alpha diversity distance\n
   | Arguments:
   | :-
@@ -853,7 +857,7 @@ def alpha_biodiversity_stats(df, group_labels):
     return stats
 
 
-def calculate_permanova_stat(df, group_labels):
+def calculate_permanova_stat(df: pd.DataFrame, group_labels: list[str]) -> float:
   """Performs multivariate analysis of variance\n
   | Arguments:
   | :-
@@ -879,7 +883,7 @@ def calculate_permanova_stat(df, group_labels):
   return f_stat
 
 
-def permanova_with_permutation(df, group_labels, permutations = 999):
+def permanova_with_permutation(df: pd.DataFrame, group_labels: list[str], permutations: int = 999) -> tuple[float, float]:
   """Performs permutational multivariate analysis of variance\n
   | Arguments:
   | :-
@@ -899,7 +903,8 @@ def permanova_with_permutation(df, group_labels, permutations = 999):
   return observed_f, p_value
 
 
-def alr_transformation(df, reference_component_index, group1, group2, gamma = 0.1, custom_scale = 0):
+def alr_transformation(df: pd.DataFrame, reference_component_index: int, group1: list[str | int], group2: list[str | int],
+                       gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """Given a reference feature, performs additive log-ratio transformation (ALR) on the data\n
   | Arguments:
   | :-
@@ -936,7 +941,8 @@ def alr_transformation(df, reference_component_index, group1, group2, gamma = 0.
   return alr_transformed
 
 
-def get_procrustes_scores(df, group1, group2, paired = False, custom_scale = 0):
+def get_procrustes_scores(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], paired: bool = False,
+                          custom_scale: float | dict = 0) -> tuple[list[float], list[float], list[float]]:
   """For each feature, estimates it value as ALR reference component\n
   | Arguments:
   | :-
@@ -969,7 +975,8 @@ def get_procrustes_scores(df, group1, group2, paired = False, custom_scale = 0):
   return [a * (1/b) for a, b in zip(procrustes_corr, variances)], procrustes_corr, variances
 
 
-def get_additive_logratio_transformation(df, group1, group2, paired = False, gamma = 0.1, custom_scale = 0):
+def get_additive_logratio_transformation(df: pd.DataFrame, group1: list[str | int], group2: list[str | int],
+                                         paired: bool = False, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """Identifies ALR reference component and transforms data according to ALR\n
   | Arguments:
   | :-
@@ -997,7 +1004,7 @@ def get_additive_logratio_transformation(df, group1, group2, paired = False, gam
   return alr
 
 
-def correct_multiple_testing(pvals, alpha, correction_method = "two-stage"):
+def correct_multiple_testing(pvals: list[float] | np.ndarray, alpha: float, correction_method: str = "two-stage") -> tuple[list[float], list[bool]]:
   """Corrects p-values for multiple testing, by default with the two-stage Benjamini-Hochberg procedure\n
   | Arguments:
   | :-
@@ -1022,7 +1029,7 @@ def correct_multiple_testing(pvals, alpha, correction_method = "two-stage"):
   return corrpvals, significance
 
 
-def omega_squared(row, groups):
+def omega_squared(row: pd.Series | np.ndarray, groups: list[str]) -> float:
   """Calculates Omega squared, as an effect size in an ANOVA setting\n
   | Arguments:
   | :-
@@ -1039,7 +1046,7 @@ def omega_squared(row, groups):
   return omega_squared
 
 
-def get_glycoform_diff(df_res, alpha = 0.05, level = 'peptide'):
+def get_glycoform_diff(df_res: pd.DataFrame, alpha: float = 0.05, level: str = 'peptide') -> pd.DataFrame:
   """Calculates differential expression of glycoforms of either a peptide or a whole protein\n
   | Arguments:
   | :-
@@ -1065,7 +1072,7 @@ def get_glycoform_diff(df_res, alpha = 0.05, level = 'peptide'):
   return df_out.sort_values(by = 'corr p-val')
 
 
-def get_glm(group, glycan_features = ['H', 'N', 'A', 'F', 'G']):
+def get_glm(group: pd.DataFrame, glycan_features: list[str] = ['H', 'N', 'A', 'F', 'G']) -> tuple[str | str, list[str]]:
   """given glycoform data from a glycosite, constructs & fits a GLM formula for main+interaction effects of explaining glycoform abundance\n
   | Arguments:
   | :-
@@ -1091,7 +1098,7 @@ def get_glm(group, glycan_features = ['H', 'N', 'A', 'F', 'G']):
     return (f"GLM fitting failed: {str(e)}", [])
 
 
-def process_glm_results(df, alpha, glycan_features):
+def process_glm_results(df: pd.DataFrame, alpha: float, glycan_features: list[str]) -> pd.DataFrame:
   """tests for interaction effects of glycan features and the condition on glycoform abundance via a GLM\n
   | Arguments:
   | :-
@@ -1123,7 +1130,7 @@ def process_glm_results(df, alpha, glycan_features):
   return df_out.sort_values(by = 'Condition_corr_pval')
 
 
-def partial_corr(x, y, controls, motifs = False):
+def partial_corr(x: np.ndarray, y: np.ndarray, controls: np.ndarray, motifs: bool = False) -> tuple[float, float]:
   """Compute regularized partial correlation of x and y, controlling for multiple other variables in controls\n
   | Arguments:
   | :-
@@ -1147,8 +1154,8 @@ def partial_corr(x, y, controls, motifs = False):
   return corr, pval
 
 
-def estimate_technical_variance(df, group1, group2, num_instances = 128,
-                                gamma = 0.1, custom_scale = 0):
+def estimate_technical_variance(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], num_instances: int = 128,
+                                gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """Monte Carlo sampling from the Dirichlet distribution with relative abundances as concentration, followed by CLR transformation.\n
   | Arguments:
   | :-
@@ -1177,7 +1184,8 @@ def estimate_technical_variance(df, group1, group2, num_instances = 128,
   return transformed_df
 
 
-def perform_tests_monte_carlo(group_a, group_b, num_instances = 128, paired = False):
+def perform_tests_monte_carlo(group_a: pd.DataFrame, group_b: pd.DataFrame, num_instances: int = 128,
+                              paired: bool = False) -> tuple[list[float], list[float], list[float]]:
   """Perform tests on each Monte Carlo instance, apply Benjamini-Hochberg correction, and calculate effect sizes and variances.\n
   | Arguments:
   | :-

--- a/glycowork/ml/model_training.py
+++ b/glycowork/ml/model_training.py
@@ -85,27 +85,19 @@ def enable_running_stats(model: torch.nn.Module # model to enable batch norm
     model.apply(_enable)
 
 
-def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.DataLoader], criterion: torch.nn.Module,
-                optimizer: torch.optim.Optimizer, scheduler: torch.optim.lr_scheduler._LRScheduler,
-                num_epochs: int = 25, patience: int = 50, mode: str = 'classification', mode2: str = 'multi',
-                return_metrics: bool = False
-                ) -> Union[torch.nn.Module, tuple[torch.nn.Module, dict[str, dict[str, list[float]]]]]:
-    """trains a deep learning model on predicting glycan properties\n
-    | Arguments:
-    | :-
-    | model (PyTorch object): graph neural network (such as SweetNet) for analyzing glycans
-    | dataloaders (PyTorch object): dictionary of dataloader objects with keys 'train' and 'val'
-    | criterion (PyTorch object): PyTorch loss function
-    | optimizer (PyTorch object): PyTorch optimizer
-    | scheduler (PyTorch object): PyTorch learning rate decay
-    | num_epochs (int): number of epochs for training; default:25
-    | patience (int): number of epochs without improvement until early stop; default:50
-    | mode (string): 'classification', 'multilabel', or 'regression'; default:classification
-    | mode2 (string): further specifying classification into 'multi' or 'binary' classification;default:multi\n
-    | return_metrics (bool): whether to return metrics, if false, plots will be generated; default:False\n
-    | Returns:
-    | :-
-    | Returns the best model seen during training"""
+def train_model(model: torch.nn.Module, # graph neural network for analyzing glycans
+               dataloaders: Dict[str, torch.utils.data.DataLoader], # dict with 'train' and 'val' loaders
+               criterion: torch.nn.Module, # PyTorch loss function
+               optimizer: torch.optim.Optimizer, # PyTorch optimizer, has to be SAM if mode != "regression"
+               scheduler: torch.optim.lr_scheduler._LRScheduler, # PyTorch learning rate decay
+               num_epochs: int = 25, # number of epochs for training
+               patience: int = 50, # epochs without improvement until early stop
+               mode: str = 'classification', # 'classification', 'multilabel', or 'regression'
+               mode2: str = 'multi', # 'multi' or 'binary' classification
+               return_metrics: bool = False, # whether to return metrics
+              ) -> Union[torch.nn.Module, tuple[torch.nn.Module, dict[str, dict[str, list[float]]]]]: # best model from training and the training and validation metrics
+    "trains a deep learning model on predicting glycan properties"
+
     since = time.time()
     early_stopping = EarlyStopping(patience=patience, verbose=True)
     best_model_wts = copy.deepcopy(model.state_dict())
@@ -119,7 +111,7 @@ def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.
     else:
         blank_metrics = {"loss": [], "mse": [], "mae": [], "r2": []}
 
-    metrics = {"train": copy.copy(blank_metrics), "val": copy.copy(blank_metrics)}
+    metrics = {"train": copy.deepcopy(blank_metrics), "val": copy.deepcopy(blank_metrics)}
 
     for epoch in range(num_epochs):
         print('Epoch {}/{}'.format(epoch, num_epochs - 1))
@@ -131,7 +123,7 @@ def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.
             else:
                 model.eval()
 
-            running_metrics = copy.copy(blank_metrics)
+            running_metrics = copy.deepcopy(blank_metrics)
             running_metrics["weights"] = []
 
             for data in dataloaders[phase]:

--- a/glycowork/ml/model_training.py
+++ b/glycowork/ml/model_training.py
@@ -1,7 +1,7 @@
 import copy
 import time
 import math
-from typing import Any, Callable, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 import xgboost as xgb
@@ -22,15 +22,10 @@ from glycowork.motif.annotate import annotate_dataset
 
 
 class EarlyStopping:
-    """Early stops the training if validation loss doesn't improve after a given patience."""
-    def __init__(self, patience: int = 7, verbose: bool = False) -> None:
-        """
-        Args:
-            patience (int): How long to wait after last time validation loss improved.
-                            Default: 7
-            verbose (bool): If True, prints a message for each validation loss improvement.
-                            Default: False
-        """
+    def __init__(self, patience: int = 7, # epochs to wait after last improvement
+                 verbose: bool = False # whether to print messages
+                ) -> None:
+        "Early stops the training if validation loss doesn't improve after a given patience"
         self.patience = patience
         self.verbose = verbose
         self.counter = 0
@@ -39,9 +34,7 @@ class EarlyStopping:
         self.val_loss_min = 0
 
     def __call__(self, val_loss: float, model: torch.nn.Module) -> None:
-
         score = -val_loss
-
         if self.best_score is None:
             self.best_score = score
             self.save_checkpoint(val_loss, model)
@@ -63,11 +56,15 @@ class EarlyStopping:
         self.val_loss_min = val_loss
 
 
-def sigmoid(x: float) -> float:
+def sigmoid(x: float # input value
+          ) -> float: # sigmoid transformed value
+    "Apply sigmoid transformation to input"
     return 1 / (1 + math.exp(-x))
 
 
-def disable_running_stats(model: torch.nn.Module) -> None:
+def disable_running_stats(model: torch.nn.Module # model to disable batch norm
+                       ) -> None:
+    "Disable batch normalization running statistics"
 
     def _disable(module):
         if isinstance(module, torch.nn.BatchNorm1d):
@@ -77,7 +74,9 @@ def disable_running_stats(model: torch.nn.Module) -> None:
     model.apply(_disable)
 
 
-def enable_running_stats(model: torch.nn.Module) -> None:
+def enable_running_stats(model: torch.nn.Module # model to enable batch norm
+                      ) -> None:
+    "Enable batch normalization running statistics"
 
     def _enable(module):
         if isinstance(module, torch.nn.BatchNorm1d) and hasattr(module, "backup_momentum"):
@@ -279,9 +278,14 @@ def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.
 
 
 class SAM(torch.optim.Optimizer):
-    # Adapted from https://github.com/davda54/sam
-    def __init__(self, params: list[torch.nn.Parameter],  base_optimizer: type[torch.optim.Optimizer],
-                 rho: float = 0.5, alpha: float = 0.0, adaptive: bool = False, **kwargs) -> None:
+    def __init__(self, params: List[torch.nn.Parameter], # model parameters
+                 base_optimizer: type[torch.optim.Optimizer], # base PyTorch optimizer type
+                 rho: float = 0.5, # size of neighborhood to explore
+                 alpha: float = 0.0, # surrogate gap minimization coefficient
+                 adaptive: bool = False, # whether to use adaptive SAM
+                 **kwargs # additional optimizer arguments
+                ) -> None:
+        "Sharpness-Aware Minimization (SAM) optimizer adapted from https://github.com/davda54/sam"
         assert rho >= 0.0, f"Invalid rho, should be non-negative: {rho}"
         assert alpha >= 0.0, f"Invalid alpha, should be non-negative: {alpha}"
 
@@ -294,7 +298,9 @@ class SAM(torch.optim.Optimizer):
         self.minimize_surrogate_gap = any(group["alpha"] > 0.0 for group in self.param_groups)
 
     @torch.no_grad()
-    def first_step(self, zero_grad: bool = False) -> None:
+    def first_step(self, zero_grad: bool = False # whether to zero gradients after step
+                 ) -> None:
+        "Performs first optimization step to find adversarial weights"
         grad_norm = self._grad_norm()
         for group in self.param_groups:
             scale = group["rho"] / (grad_norm + 1e-12)
@@ -312,7 +318,9 @@ class SAM(torch.optim.Optimizer):
             self.zero_grad()
 
     @torch.no_grad()
-    def second_step(self, zero_grad: bool = False) -> None:
+    def second_step(self, zero_grad: bool = False # whether to zero gradients after step
+                  ) -> None:
+        "Performs second optimization step with regular weights"
         for group in self.param_groups:
             for p in group["params"]:
                 if p.grad is None:
@@ -373,12 +381,12 @@ class SAM(torch.optim.Optimizer):
 
 
 class Poly1CrossEntropyLoss(torch.nn.Module):
-    def __init__(self, num_classes: int, epsilon: float = 1.0, reduction: str = "mean", weight: torch.Tensor | None = None) -> None:
-        """Create instance of Poly1CrossEntropyLoss
-        :param num_classes:
-        :param epsilon:
-        :param reduction: one of none|sum|mean, apply reduction to final loss tensor
-        :param weight: manual rescaling weight for each class, passed to Cross-Entropy loss"""
+    def __init__(self, num_classes: int, # number of classes
+                 epsilon: float = 1.0, # weight of poly1 term
+                 reduction: str = "mean", # reduction method for loss
+                 weight: Optional[torch.Tensor] = None # manual class weights
+                ) -> None:
+        "Polynomial cross entropy loss for improved training stability"
         super(Poly1CrossEntropyLoss, self).__init__()
         self.num_classes = num_classes
         self.epsilon = epsilon
@@ -386,11 +394,10 @@ class Poly1CrossEntropyLoss(torch.nn.Module):
         self.weight = weight
         return
 
-    def forward(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        """Forward pass
-        :param logits: tensor of shape [N, num_classes]
-        :param labels: tensor of shape [N]
-        :return: poly cross-entropy loss"""
+    def forward(self, logits: torch.Tensor, # predicted class probabilities [N, num_classes]
+               labels: torch.Tensor # ground truth labels [N]
+              ) -> torch.Tensor: # computed loss value
+        "Compute poly cross-entropy loss"
         if len(labels.shape) == 2 and labels.shape[1] == self.num_classes:
             labels_onehot = labels.to(device = logits.device, dtype = logits.dtype)
             labels = torch.argmax(labels, dim = 1)
@@ -411,23 +418,16 @@ class Poly1CrossEntropyLoss(torch.nn.Module):
         return poly1
 
 
-def training_setup(model: torch.nn.Module, lr: float, lr_patience: int = 4, factor: float = 0.2, weight_decay: float = 0.0001,
-                  mode: str = 'multiclass', num_classes: int = 2, gsam_alpha: float = 0.) -> tuple[torch.optim.Optimizer, 
-                                                 torch.optim.lr_scheduler._LRScheduler, torch.nn.Module]:
-    """prepares optimizer, learning rate scheduler, and loss criterion for model training\n
-    | Arguments:
-    | :-
-    | model (PyTorch object): graph neural network (such as SweetNet) for analyzing glycans
-    | lr (float): learning rate
-    | lr_patience (int): number of epochs without validation loss improvement before reducing the learning rate;default:4
-    | factor (float): factor by which learning rate is multiplied upon reduction
-    | weight_decay (float): regularization parameter for the optimizer; default:0.001
-    | mode (string): 'multiclass': classification with multiple classes, 'multilabel': predicting several labels at the same time, 'binary':binary classification, 'regression': regression; default:'multiclass'
-    | num_classes (int): number of classes; only used when mode == 'multiclass' or 'multilabel'
-    | gsam_alpha (float): if higher than zero, uses GSAM instead of SAM for the optimizer\n
-    | Returns:
-    | :-
-    | Returns optimizer, learning rate scheduler, and loss criterion objects"""
+def training_setup(model: torch.nn.Module, # graph neural network for analyzing glycans
+                  lr: float, # learning rate
+                  lr_patience: int = 4, # epochs before reducing learning rate
+                  factor: float = 0.2, # factor to multiply lr on reduction
+                  weight_decay: float = 0.0001, # regularization parameter
+                  mode: str = 'multiclass', # type of prediction task
+                  num_classes: int = 2, # number of classes for classification
+                  gsam_alpha: float = 0. # if >0, uses GSAM instead of SAM optimizer
+                 ) -> Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler._LRScheduler, torch.nn.Module]: # optimizer, scheduler, criterion
+    "prepares optimizer, learning rate scheduler, and loss criterion for model training"
     # Choose optimizer & learning rate scheduler
     if mode in {'multiclass', 'multilabel'}:
         optimizer_ft = SAM(model.parameters(), torch.optim.AdamW, alpha = gsam_alpha, lr = lr,
@@ -455,24 +455,18 @@ def training_setup(model: torch.nn.Module, lr: float, lr_patience: int = 4, fact
     return optimizer_ft, scheduler, criterion
 
 
-def train_ml_model(X_train: pd.DataFrame | list, X_test: pd.DataFrame | list, y_train: list, y_test: list, mode: str = 'classification',
-                  feature_calc: bool = False, return_features: bool = False, feature_set: list[str] = ['known', 'exhaustive'],
-                  additional_features_train: pd.DataFrame | None = None,
-                  additional_features_test: pd.DataFrame | None = None) -> Union[xgb.XGBModel, tuple[xgb.XGBModel, pd.DataFrame, pd.DataFrame]]:
-    """wrapper function to train standard machine learning models on glycans\n
-    | Arguments:
-    | :-
-    | X_train, X_test (list or dataframe): either lists of glycans (needs feature_calc = True) or motif dataframes such as from annotate_dataset
-    | y_train, y_test (list): lists of labels
-    | mode (string): 'classification' or 'regression'; default:'classification'
-    | feature_calc (bool): set to True for calculating motifs from glycans; default:False
-    | return_features (bool): whether to return calculated features; default:False
-    | feature_set (list): which feature set to use for annotations, add more to list to expand; default:['known','exhaustive']; options are: 'known' (hand-crafted glycan features), 'graph' (structural graph features of glycans), and 'exhaustive' (all mono- and disaccharide features)
-    | additional_features_train (dataframe): additional features (apart from glycans) to be used for training. Has to be of the same length as X_train; default:None
-    | additional_features_test (dataframe): additional features (apart from glycans) to be used for evaluation. Has to be of the same length as X_test; default:None\n
-    | Returns:
-    | :-
-    | Returns trained model"""
+def train_ml_model(X_train: Union[pd.DataFrame, List], # training data/glycans
+                  X_test: Union[pd.DataFrame, List], # test data/glycans
+                  y_train: List, # training labels
+                  y_test: List, # test labels
+                  mode: str = 'classification', # 'classification' or 'regression'
+                  feature_calc: bool = False, # calculate motifs from glycans
+                  return_features: bool = False, # return calculated features
+                  feature_set: List[str] = ['known', 'exhaustive'], # feature set for annotations
+                  additional_features_train: Optional[pd.DataFrame] = None, # additional training features
+                  additional_features_test: Optional[pd.DataFrame] = None # additional test features
+                 ) -> Union[xgb.XGBModel, Tuple[xgb.XGBModel, pd.DataFrame, pd.DataFrame]]: # trained model and optionally features
+    "wrapper function to train standard machine learning models on glycans"
     # Choose model type
     if mode == 'classification':
         model = xgb.XGBClassifier(random_state = 42, n_estimators = 100,  max_depth = 3)
@@ -516,11 +510,9 @@ def train_ml_model(X_train: pd.DataFrame | list, X_test: pd.DataFrame | list, y_
         return model
 
 
-def analyze_ml_model(model: xgb.XGBModel) -> None:
-    """plots relevant features for model prediction\n
-    | Arguments:
-    | :-
-    | model (model object): trained machine learning model from train_ml_model"""
+def analyze_ml_model(model: xgb.XGBModel # trained ML model from train_ml_model
+                   ) -> None:
+    "plots relevant features for model prediction"
     # Get important features
     feat_imp = model.get_booster().get_score(importance_type = 'gain')
     feat_imp = pd.DataFrame(feat_imp, index = [0]).T
@@ -539,17 +531,12 @@ def analyze_ml_model(model: xgb.XGBModel) -> None:
     plt.show()
 
 
-def get_mismatch(model: xgb.XGBModel, X_test: pd.DataFrame, y_test: list, n: int = 10) -> list[tuple[Any, float]]:
-    """analyzes misclassifications of trained machine learning model\n
-    | Arguments:
-    | :-
-    | model (model object): trained machine learning model from train_ml_model
-    | X_test (dataframe): motif dataframe used for validating model
-    | y_test (list): list of labels
-    | n (int): number of returned misclassifications; default:10\n
-    | Returns:
-    | :-
-    | Returns tuples of misclassifications and their predicted probability"""
+def get_mismatch(model: xgb.XGBModel, # trained ML model from train_ml_model
+                X_test: pd.DataFrame, # motif dataframe for validation
+                y_test: List, # test labels
+                n: int = 10 # number of returned misclassifications
+               ) -> List[Tuple[Any, float]]: # misclassifications and predicted probabilities
+    "analyzes misclassifications of trained machine learning model"
     # Get predictions
     preds = model.predict(X_test)
     preds_proba = model.predict_proba(X_test)

--- a/glycowork/ml/model_training.py
+++ b/glycowork/ml/model_training.py
@@ -169,7 +169,7 @@ def train_model(model: torch.nn.Module, # graph neural network for analyzing gly
 
                 # Collecting relevant metrics
                 running_metrics["loss"].append(loss.item())
-                running_metrics["weights"].append(len(batch))
+                running_metrics["weights"].append(batch.max().cpu() + 1)
 
                 y_det = y.detach().cpu().numpy()
                 pred_det = pred.cpu().detach().numpy()
@@ -210,7 +210,7 @@ def train_model(model: torch.nn.Module, # graph neural network for analyzing gly
                     best_loss = metrics[phase]["loss"][-1]
                     best_model_wts = copy.deepcopy(model.state_dict())
 
-                    # Extract ACC or MSE of the new best model
+                    # Extract the lead metric (ACC, LRAP, or MSE) of the new best model
                     if mode == 'classification':
                         best_lead_metric = metrics[phase]["acc"][-1]
                     elif mode == 'multilabel':

--- a/glycowork/ml/models.py
+++ b/glycowork/ml/models.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal, Optional
+from typing import Dict, Optional, Tuple, Union, Literal
 
 import numpy as np
 try:
@@ -16,16 +16,11 @@ from glycowork.glycan_data.loader import lib, download_model
 
 
 class SweetNet(torch.nn.Module):
-    """given glycan graphs as input, predicts properties via a graph neural network\n
-    | Arguments:
-    | :-
-    | lib_size (int): number of unique tokens for graph nodes; usually len(lib)
-    | num_classes (int): number of output classes; only >1 for multilabel classification; default:1\n
-    | Returns:
-    | :-
-    | Returns batch-wise predictions"""
-    def __init__(self, lib_size: int, num_classes: int = 1, hidden_dim: int = 128) -> None:
-        super(SweetNet, self).__init__()
+    def __init__(self, lib_size: int, # number of unique tokens for graph nodes
+                 num_classes: int = 1, # number of output classes (>1 for multilabel)
+                 hidden_dim: int = 128 # dimension of hidden layers
+                ) -> None:
+        "given glycan graphs as input, predicts properties via a graph neural network"
 
         # Convolution operations on the graph
         self.conv1 = GraphConv(hidden_dim, hidden_dim)
@@ -43,7 +38,9 @@ class SweetNet(torch.nn.Module):
         self.act1 = torch.nn.LeakyReLU()
         self.act2 = torch.nn.LeakyReLU()
 
-    def forward(self, x: torch.Tensor, edge_index: torch.Tensor, batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, x: torch.Tensor, edge_index: torch.Tensor, batch: torch.Tensor,
+                inference: bool = False) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+
         # Getting node features
         x = self.item_embedding(x)
         x = x.squeeze(1)
@@ -68,11 +65,8 @@ class SweetNet(torch.nn.Module):
 
 
 class NSequonPred(torch.nn.Module):
-    """given an ESM1b representation of N and 20 AA up + downstream, predicts whether it's a sequon\n
-    | Returns:
-    | :-
-    | Returns batch-wise predictions"""
     def __init__(self) -> None:
+        "given an ESM1b representation of N and 20 AA up + downstream, predicts whether it's a sequon"
         super(NSequonPred, self).__init__()
 
         self.fc1 = torch.nn.Linear(1280, 512)
@@ -92,14 +86,19 @@ class NSequonPred(torch.nn.Module):
       return x
 
 
-def sigmoid_range(x: torch.Tensor, low: float, high: float) -> torch.Tensor:
+def sigmoid_range(x: torch.Tensor, # input tensor
+                 low: float, # lower bound of range
+                 high: float # upper bound of range
+                ) -> torch.Tensor: # sigmoid transformed tensor in range (low,high)
     "Sigmoid function with range `(low, high)`"
     return torch.sigmoid(x) * (high - low) + low
 
 
 class SigmoidRange(torch.nn.Module):
-    "Sigmoid module with range `(low, x_max)`"
-    def __init__(self, low: float, high: float) -> None:
+    def __init__(self, low: float, # lower bound of range
+                 high: float # upper bound of range
+                ) -> None:
+      "Sigmoid module with range `(low, high)`"
       super(SigmoidRange, self).__init__()
       self.low, self.high = low, high
 
@@ -108,20 +107,14 @@ class SigmoidRange(torch.nn.Module):
 
 
 class LectinOracle(torch.nn.Module):
-  """given glycan graphs and protein representations as input, predicts protein-glycan binding\n
-  | Arguments:
-  | :-
-  | input_size_glyco (int): number of unique tokens for graph nodes; usually len(lib)
-  | hidden_size (int): layer size for the graph convolutions; default:128
-  | num_classes (int): number of output classes; only >1 for multilabel classification; default:1
-  | data_min (float): minimum observed value in training data; default: -11.355
-  | data_max (float): maximum observed value in training data; default: 23.892
-  | input_size_prot (int): dimensionality of protein representations used as input; default:1280\n
-  | Returns:
-  | :-
-  | Returns batch-wise predictions"""
-  def __init__(self, input_size_glyco: int, hidden_size: int = 128, num_classes: int = 1, 
-                 data_min: float = -11.355, data_max: float = 23.892, input_size_prot: int = 1280) -> None:
+  def __init__(self, input_size_glyco: int, # number of unique tokens for graph nodes
+                 hidden_size: int = 128, # layer size for graph convolutions
+                 num_classes: int = 1, # number of output classes (>1 for multilabel)
+                 data_min: float = -11.355, # minimum observed value in training data
+                 data_max: float = 23.892, # maximum observed value in training data
+                 input_size_prot: int = 1280 # dimensionality of protein representations
+                ) -> None:
+    "given glycan graphs and protein representations as input, predicts protein-glycan binding"
     super(LectinOracle, self).__init__()
     self.input_size_prot = input_size_prot
     self.input_size_glyco = input_size_glyco
@@ -156,8 +149,8 @@ class LectinOracle(torch.nn.Module):
     self.act1 = torch.nn.LeakyReLU()
     self.sigmoid = SigmoidRange(self.data_min, self.data_max)
 
-  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor, 
-                batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor, batch: torch.Tensor,
+              inference: bool = False) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
     # Fully connected part for the protein
     embedded_prot = self.bn_prot1(self.act_prot1(self.dp_prot1(self.prot_encoder1(prot))))
     embedded_prot = self.bn_prot2(self.act_prot2(self.dp_prot2(self.prot_encoder2(embedded_prot))))
@@ -196,20 +189,14 @@ class LectinOracle(torch.nn.Module):
 
 
 class LectinOracle_flex(torch.nn.Module):
-  """given glycan graphs and protein sequences as input, predicts protein-glycan binding\n
-  | Arguments:
-  | :-
-  | input_size_glyco (int): number of unique tokens for graph nodes; usually len(lib)
-  | hidden_size (int): layer size for the graph convolutions; default:128
-  | num_classes (int): number of output classes; only >1 for multilabel classification; default:1
-  | data_min (float): minimum observed value in training data; default: -11.355
-  | data_max (float): maximum observed value in training data; default: 23.892
-  | input_size_prot (int): maximum length of protein sequence for padding/cutting; default:1000\n
-  | Returns:
-  | :-
-  | Returns batch-wise predictions"""
-  def __init__(self, input_size_glyco: int, hidden_size: int = 128, num_classes: int = 1,
-                 data_min: float = -11.355, data_max: float = 23.892, input_size_prot: int = 1000) -> None:
+  def __init__(self, input_size_glyco: int, # number of unique tokens for graph nodes
+                 hidden_size: int = 128, # layer size for graph convolutions
+                 num_classes: int = 1, # number of output classes (>1 for multilabel)
+                 data_min: float = -11.355, # minimum observed value in training data
+                 data_max: float = 23.892, # maximum observed value in training data
+                 input_size_prot: int = 1000 # maximum protein sequence length for padding/cutting
+                ) -> None:
+    "given glycan graphs and protein sequences as input, predicts protein-glycan binding"
     super(LectinOracle_flex, self).__init__()
     self.input_size_prot = input_size_prot
     self.input_size_glyco = input_size_glyco
@@ -255,8 +242,8 @@ class LectinOracle_flex(torch.nn.Module):
     self.act1_n = torch.nn.LeakyReLU()
     self.sigmoid = SigmoidRange(self.data_min, self.data_max)
 
-  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor,
-                batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor, batch: torch.Tensor,
+              inference: bool = False) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
     # ESM-1b mimicking
     prot = self.dp1(self.act1(self.bn1(self.fc1(prot))))
     prot = self.dp2(self.act2(self.bn2(self.fc2(prot))))
@@ -291,13 +278,11 @@ class LectinOracle_flex(torch.nn.Module):
       return out
 
 
-def init_weights(model: torch.nn.Module, mode: str = 'sparse', sparsity: float = 0.1) -> None:
-    """initializes linear layers of PyTorch model with a weight initialization\n
-    | Arguments:
-    | :-
-    | model (Pytorch object): neural network (such as SweetNet) for analyzing glycans
-    | mode (string): which initialization algorithm; choices are 'sparse','kaiming','xavier';default:'sparse'
-    | sparsity (float): proportion of sparsity after initialization; default:0.1 / 10%"""
+def init_weights(model: torch.nn.Module, # neural network for analyzing glycans
+                mode: str = 'sparse', # initialization algorithm: 'sparse', 'kaiming', 'xavier'
+                sparsity: float = 0.1 # proportion of sparsity after initialization
+               ) -> None:
+    "initializes linear layers of PyTorch model with a weight initialization"
     if isinstance(model, torch.nn.Linear):
         if mode == 'sparse':
             torch.nn.init.sparse_(model.weight, sparsity = sparsity)
@@ -309,19 +294,13 @@ def init_weights(model: torch.nn.Module, mode: str = 'sparse', sparsity: float =
             print("This initialization option is not supported.")
 
 
-def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_flex", "NSequonPred"],
-               num_classes: int, libr: Optional[dict[str, int]] = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
-    """wrapper to instantiate model, initialize it, and put it on the GPU\n
-    | Arguments:
-    | :-
-    | model_type (string): string indicating the type of model
-    | num_classes (int): number of unique classes for classification
-    | libr (dict): dictionary of form glycoletter:index\n
-    | trained (bool): whether to use pretrained model; default:False
-    | hidden_dim (int): hidden dimension for the model (currently only for SweetNet); default:128\n
-    | Returns:
-    | :-
-    | Returns PyTorch model object"""
+def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_flex", "NSequonPred"], # type of model to create
+              num_classes: int, # number of unique classes for classification
+              libr: Optional[Dict[str, int]] = None, # dictionary of form glycoletter:index
+              trained: bool = False, # whether to use pretrained model
+              hidden_dim: int = 128 # hidden dimension for the model (SweetNet only)
+             ) -> torch.nn.Module: # initialized PyTorch model
+    "wrapper to instantiate model, initialize it, and put it on the GPU"
     if libr is None:
       libr = lib
     if model_type == 'SweetNet':

--- a/glycowork/ml/models.py
+++ b/glycowork/ml/models.py
@@ -23,9 +23,8 @@ class SweetNet(torch.nn.Module):
     | num_classes (int): number of output classes; only >1 for multilabel classification; default:1\n
     | Returns:
     | :-
-    | Returns batch-wise predictions
-    """
-    def __init__(self, lib_size, num_classes: int = 1, hidden_dim: int = 128):
+    | Returns batch-wise predictions"""
+    def __init__(self, lib_size: int, num_classes: int = 1, hidden_dim: int = 128) -> None:
         super(SweetNet, self).__init__()
 
         # Convolution operations on the graph
@@ -44,8 +43,7 @@ class SweetNet(torch.nn.Module):
         self.act1 = torch.nn.LeakyReLU()
         self.act2 = torch.nn.LeakyReLU()
 
-    def forward(self, x, edge_index, batch, inference = False):
-
+    def forward(self, x: torch.Tensor, edge_index: torch.Tensor, batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         # Getting node features
         x = self.item_embedding(x)
         x = x.squeeze(1)
@@ -73,9 +71,8 @@ class NSequonPred(torch.nn.Module):
     """given an ESM1b representation of N and 20 AA up + downstream, predicts whether it's a sequon\n
     | Returns:
     | :-
-    | Returns batch-wise predictions
-    """
-    def __init__(self):
+    | Returns batch-wise predictions"""
+    def __init__(self) -> None:
         super(NSequonPred, self).__init__()
 
         self.fc1 = torch.nn.Linear(1280, 512)
@@ -87,7 +84,7 @@ class NSequonPred(torch.nn.Module):
         self.bn2 = torch.nn.BatchNorm1d(256)
         self.bn3 = torch.nn.BatchNorm1d(64)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
       x = F.dropout(F.rrelu(self.bn1(self.fc1(x))), p = 0.2, training = self.training)
       x = F.dropout(F.rrelu(self.bn2(self.fc2(x))), p = 0.2, training = self.training)
       x = F.dropout(F.rrelu(self.bn3(self.fc3(x))), p = 0.1, training = self.training)
@@ -95,19 +92,18 @@ class NSequonPred(torch.nn.Module):
       return x
 
 
-def sigmoid_range(x, low, high):
+def sigmoid_range(x: torch.Tensor, low: float, high: float) -> torch.Tensor:
     "Sigmoid function with range `(low, high)`"
     return torch.sigmoid(x) * (high - low) + low
 
 
 class SigmoidRange(torch.nn.Module):
     "Sigmoid module with range `(low, x_max)`"
-
-    def __init__(self, low, high):
+    def __init__(self, low: float, high: float) -> None:
       super(SigmoidRange, self).__init__()
       self.low, self.high = low, high
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return sigmoid_range(x, self.low, self.high)
 
 
@@ -123,10 +119,9 @@ class LectinOracle(torch.nn.Module):
   | input_size_prot (int): dimensionality of protein representations used as input; default:1280\n
   | Returns:
   | :-
-  | Returns batch-wise predictions
-  """
-  def __init__(self, input_size_glyco, hidden_size = 128, num_classes = 1, data_min = -11.355,
-               data_max = 23.892, input_size_prot = 1280):
+  | Returns batch-wise predictions"""
+  def __init__(self, input_size_glyco: int, hidden_size: int = 128, num_classes: int = 1, 
+                 data_min: float = -11.355, data_max: float = 23.892, input_size_prot: int = 1280) -> None:
     super(LectinOracle, self).__init__()
     self.input_size_prot = input_size_prot
     self.input_size_glyco = input_size_glyco
@@ -161,7 +156,8 @@ class LectinOracle(torch.nn.Module):
     self.act1 = torch.nn.LeakyReLU()
     self.sigmoid = SigmoidRange(self.data_min, self.data_max)
 
-  def forward(self, prot, nodes, edge_index, batch, inference = False):
+  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor, 
+                batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Fully connected part for the protein
     embedded_prot = self.bn_prot1(self.act_prot1(self.dp_prot1(self.prot_encoder1(prot))))
     embedded_prot = self.bn_prot2(self.act_prot2(self.dp_prot2(self.prot_encoder2(embedded_prot))))
@@ -211,10 +207,9 @@ class LectinOracle_flex(torch.nn.Module):
   | input_size_prot (int): maximum length of protein sequence for padding/cutting; default:1000\n
   | Returns:
   | :-
-  | Returns batch-wise predictions
-  """
-  def __init__(self, input_size_glyco, hidden_size = 128, num_classes = 1, data_min = -11.355,
-               data_max = 23.892, input_size_prot = 1000):
+  | Returns batch-wise predictions"""
+  def __init__(self, input_size_glyco: int, hidden_size: int = 128, num_classes: int = 1,
+                 data_min: float = -11.355, data_max: float = 23.892, input_size_prot: int = 1000) -> None:
     super(LectinOracle_flex, self).__init__()
     self.input_size_prot = input_size_prot
     self.input_size_glyco = input_size_glyco
@@ -260,7 +255,8 @@ class LectinOracle_flex(torch.nn.Module):
     self.act1_n = torch.nn.LeakyReLU()
     self.sigmoid = SigmoidRange(self.data_min, self.data_max)
 
-  def forward(self, prot, nodes, edge_index, batch, inference = False):
+  def forward(self, prot: torch.Tensor, nodes: torch.Tensor, edge_index: torch.Tensor,
+                batch: torch.Tensor, inference: bool = False) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # ESM-1b mimicking
     prot = self.dp1(self.act1(self.bn1(self.fc1(prot))))
     prot = self.dp2(self.act2(self.bn2(self.fc2(prot))))
@@ -295,14 +291,13 @@ class LectinOracle_flex(torch.nn.Module):
       return out
 
 
-def init_weights(model, mode = 'sparse', sparsity = 0.1):
+def init_weights(model: torch.nn.Module, mode: str = 'sparse', sparsity: float = 0.1) -> None:
     """initializes linear layers of PyTorch model with a weight initialization\n
     | Arguments:
     | :-
     | model (Pytorch object): neural network (such as SweetNet) for analyzing glycans
     | mode (string): which initialization algorithm; choices are 'sparse','kaiming','xavier';default:'sparse'
-    | sparsity (float): proportion of sparsity after initialization; default:0.1 / 10%
-    """
+    | sparsity (float): proportion of sparsity after initialization; default:0.1 / 10%"""
     if isinstance(model, torch.nn.Linear):
         if mode == 'sparse':
             torch.nn.init.sparse_(model.weight, sparsity = sparsity)
@@ -315,7 +310,7 @@ def init_weights(model, mode = 'sparse', sparsity = 0.1):
 
 
 def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_flex", "NSequonPred"],
-               num_classes: int, libr=None, trained=False, hidden_dim: int = 128):
+               num_classes: int, libr: dict[str, int] | None = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
     """wrapper to instantiate model, initialize it, and put it on the GPU\n
     | Arguments:
     | :-
@@ -326,8 +321,7 @@ def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_fle
     | hidden_dim (int): hidden dimension for the model (currently only for SweetNet); default:128\n
     | Returns:
     | :-
-    | Returns PyTorch model object
-    """
+    | Returns PyTorch model object"""
     if libr is None:
       libr = lib
     if model_type == 'SweetNet':

--- a/glycowork/ml/models.py
+++ b/glycowork/ml/models.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal
+from typing import Literal, Optional
 
 import numpy as np
 try:
@@ -310,7 +310,7 @@ def init_weights(model: torch.nn.Module, mode: str = 'sparse', sparsity: float =
 
 
 def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_flex", "NSequonPred"],
-               num_classes: int, libr: dict[str, int] | None = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
+               num_classes: int, libr: Optional[dict[str, int]] = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
     """wrapper to instantiate model, initialize it, and put it on the GPU\n
     | Arguments:
     | :-

--- a/glycowork/ml/processing.py
+++ b/glycowork/ml/processing.py
@@ -13,7 +13,7 @@ except ImportError:
   raise ImportError("<torch or torch_geometric missing; did you do 'pip install glycowork[ml]'?>")
 
 
-def augment_glycan(glycan_data, libr, generalization_prob = 0.2):
+def augment_glycan(glycan_data: torch.utils.data.Dataset, libr: dict[str, int], generalization_prob: float = 0.2) -> torch.utils.data.Dataset:
   """Augment a single glycan by wildcarding some of its monosaccharides or linkages.\n
   | Arguments:
   | :-
@@ -22,8 +22,7 @@ def augment_glycan(glycan_data, libr, generalization_prob = 0.2):
   | generalization_prob (float): the probability (0-1) of wildcarding for every single monosaccharide/linkage; default: 0.2\n
   | Returns:
   | :-
-  | Returns the data object with partially wildcarded glycan graph
-  """
+  | Returns the data object with partially wildcarded glycan graph"""
   augmented_data = deepcopy(glycan_data)
   # Augment node labels
   for i, label in enumerate(augmented_data.string_labels):
@@ -35,23 +34,24 @@ def augment_glycan(glycan_data, libr, generalization_prob = 0.2):
 
 
 class AugmentedGlycanDataset(torch.utils.data.Dataset):
-  def __init__(self, dataset, libr, augment_prob = 0.5, generalization_prob = 0.2):
+  def __init__(self, dataset: torch.utils.data.Dataset, libr: dict[str, int], augment_prob: float = 0.5,  generalization_prob: float = 0.2) -> None:
     self.dataset = dataset
     self.augment_prob = augment_prob
     self.generalization_prob = generalization_prob
     self.libr = libr
 
-  def __len__(self):
+  def __len__(self) -> int:
     return len(self.dataset)
 
-  def __getitem__(self, idx):
+  def __getitem__(self, idx: int) -> torch.utils.data.Dataset:
     glycan_data = self.dataset[idx]
     if random() < self.augment_prob:
       glycan_data = augment_glycan(glycan_data, self.libr, self.generalization_prob)
     return glycan_data
 
 
-def dataset_to_graphs(glycan_list, labels, libr = None, label_type = torch.long):
+def dataset_to_graphs(glycan_list: list[str], labels: list[float | int], libr: dict[str, int] | None = None,
+                     label_type: torch.dtype = torch.long) -> list[torch.utils.data.Dataset]:
   """wrapper function to convert a whole list of glycans into a graph dataset\n
   | Arguments:
   | :-
@@ -61,8 +61,7 @@ def dataset_to_graphs(glycan_list, labels, libr = None, label_type = torch.long)
   | label_type (torch object): which tensor type for label, default is torch.long for binary labels, change to torch.float for continuous\n
   | Returns:
   | :-
-  | Returns list of node list / edge list / label list data tuples
-  """
+  | Returns list of node list / edge list / label list data tuples"""
   if libr is None:
     libr = lib
   glycan_cache = {}
@@ -81,9 +80,9 @@ def dataset_to_graphs(glycan_list, labels, libr = None, label_type = torch.long)
   return data
 
 
-def dataset_to_dataloader(glycan_list, labels, libr = None, batch_size = 32,
-                          shuffle = True, drop_last = False, extra_feature = None, label_type = torch.long,
-                          augment_prob = 0., generalization_prob = 0.2):
+def dataset_to_dataloader(glycan_list: list[str], labels: list[float | int], libr: dict[str, int] | None = None, batch_size: int = 32,
+                         shuffle: bool = True, drop_last: bool = False, extra_feature: list[float] | None = None, label_type: torch.dtype = torch.long,
+                         augment_prob: float = 0., generalization_prob: float = 0.2) -> torch.utils.data.DataLoader:
   """wrapper function to convert glycans and labels to a torch_geometric DataLoader\n
   | Arguments:
   | :-
@@ -99,8 +98,7 @@ def dataset_to_dataloader(glycan_list, labels, libr = None, batch_size = 32,
   | generalization_prob (float): the probability (0-1) of wildcarding for every single monosaccharide/linkage; default: 0.2\n
   | Returns:
   | :-
-  | Returns a dataloader object used for training deep learning models
-  """
+  | Returns a dataloader object used for training deep learning models"""
   if libr is None:
     libr = lib
   # Converting glycans and labels to PyTorch Geometric Data objects
@@ -115,11 +113,10 @@ def dataset_to_dataloader(glycan_list, labels, libr = None, batch_size = 32,
   return DataLoader(augmented_dataset, batch_size = batch_size, shuffle = shuffle, drop_last = drop_last)
 
 
-def split_data_to_train(glycan_list_train, glycan_list_val,
-                        labels_train, labels_val, libr = None,
-                        batch_size = 32, drop_last = False,
-                        extra_feature_train = None, extra_feature_val = None,
-                        label_type = torch.long, augment_prob = 0., generalization_prob = 0.2):
+def split_data_to_train(glycan_list_train: list[str], glycan_list_val: list[str], labels_train: list[float | int], labels_val: list[float | int],
+                       libr: dict[str, int] | None = None, batch_size: int = 32, drop_last: bool = False, extra_feature_train: list[float] | None = None,
+                       extra_feature_val: list[float] | None = None, label_type: torch.dtype = torch.long, augment_prob: float = 0.,
+                       generalization_prob: float = 0.2) -> dict[str, torch.utils.data.DataLoader]:
   """wrapper function to convert split training/test data into dictionary of dataloaders\n
   | Arguments:
   | :-
@@ -137,8 +134,7 @@ def split_data_to_train(glycan_list_train, glycan_list_val,
   | generalization_prob (float): the probability (0-1) of wildcarding for every single monosaccharide/linkage; default: 0.2\n
   | Returns:
   | :-
-  | Returns a dictionary of dataloaders for training and testing deep learning models
-  """
+  | Returns a dictionary of dataloaders for training and testing deep learning models"""
   if libr is None:
     libr = lib
   # Generating train and validation set loaders

--- a/glycowork/ml/train_test_split.py
+++ b/glycowork/ml/train_test_split.py
@@ -4,8 +4,8 @@ import random
 import pandas as pd
 
 
-def seed_wildcard_hierarchy(glycans, labels, wildcard_list,
-                            wildcard_name, r = 0.1):
+def seed_wildcard_hierarchy(glycans: list[str], labels: list[float | int | str], wildcard_list: list[str],
+                          wildcard_name: str, r: float = 0.1) -> tuple[list[str], list[float | int | str]]:
   """adds dataframe rows in which glycan parts have been replaced with the appropriate wildcards\n
   | Arguments:
   | :-
@@ -16,8 +16,7 @@ def seed_wildcard_hierarchy(glycans, labels, wildcard_list,
   | r (float): rate of replacement, default:0.1 or 10%\n
   | Returns:
   | :-
-  | Returns list of glycans (strings) and labels (flexible) where some glycan parts have been replaced with wildcard_name
-  """
+  | Returns list of glycans (strings) and labels (flexible) where some glycan parts have been replaced with wildcard_name"""
   added_glycans_labels = [(glycan.replace(j, wildcard_name), label)
                              for glycan, label in zip(glycans, labels)
                              for j in wildcard_list if j in glycan and random.uniform(0, 1) < r]
@@ -27,8 +26,9 @@ def seed_wildcard_hierarchy(glycans, labels, wildcard_list,
   return glycans, labels
 
 
-def hierarchy_filter(df_in, rank = 'Domain', min_seq = 5, wildcard_seed = False, wildcard_list = None,
-                     wildcard_name = None, r = 0.1, col = 'glycan'):
+def hierarchy_filter(df_in: pd.DataFrame, rank: str = 'Domain', min_seq: int = 5, wildcard_seed: bool = False,
+                    wildcard_list: list[str] | None = None, wildcard_name: str | None = None, r: float = 0.1,
+                    col: str = 'glycan') -> tuple[list[str], list[str], list[int], list[int], list[int], list[str], dict[str, int]]:
   """stratified data split in train/test at the taxonomic level, removing duplicate glycans and infrequent classes\n
   | Arguments:
   | :-
@@ -46,8 +46,7 @@ def hierarchy_filter(df_in, rank = 'Domain', min_seq = 5, wildcard_seed = False,
   | train_y, val_y (lists of taxonomic labels (mapped integers))
   | id_val (taxonomic labels in text form (strings))
   | class_list (list of unique taxonomic classes (strings))
-  | class_converter (dictionary to map mapped integers back to text labels)
-  """
+  | class_converter (dictionary to map mapped integers back to text labels)"""
   df = copy.deepcopy(df_in)
   # Get all non-selected ranks and drop from df
   rank_list = ['Species', 'Genus', 'Family', 'Order',
@@ -95,7 +94,8 @@ def hierarchy_filter(df_in, rank = 'Domain', min_seq = 5, wildcard_seed = False,
   return train_x, val_x, train_y, val_y, id_val, class_list, class_converter
 
 
-def general_split(glycans, labels, test_size = 0.2):
+def general_split(glycans: list[str], labels: list[float | int | str],
+                 test_size: float = 0.2) -> tuple[list[str], list[str], list[float | int | str], list[float | int | str]]:
   """splits glycans and labels into train / test sets\n
   | Arguments:
   | :-
@@ -104,13 +104,12 @@ def general_split(glycans, labels, test_size = 0.2):
   | test_size (float): % size of test set; default:0.2 / 20%\n
   | Returns:
   | :-
-  | Returns X_train, X_test, y_train, y_test
-  """
+  | Returns X_train, X_test, y_train, y_test"""
   return train_test_split(glycans, labels, shuffle = True,
                           test_size = test_size, random_state = 42)
 
 
-def prepare_multilabel(df, rank = 'Species', glycan_col = 'glycan'):
+def prepare_multilabel(df: pd.DataFrame, rank: str = 'Species', glycan_col: str = 'glycan') -> tuple[list[str], list[list[float]]]:
   """converts a one row per glycan-species/tissue/disease association file to a format of one glycan - all associations\n
   | Arguments:
   | :-
@@ -120,8 +119,7 @@ def prepare_multilabel(df, rank = 'Species', glycan_col = 'glycan'):
   | Returns:
   | :-
   | (1) list of unique glycans in df
-  | (2) list of lists, where each inner list are all the labels of a glycan
-  """
+  | (2) list of lists, where each inner list are all the labels of a glycan"""
   glycans = list(set(df[glycan_col].values.tolist()))
   class_list = list(set(df[rank].values.tolist()))
   labels = [[0.]*len(class_list) for k in range(len(glycans))]

--- a/glycowork/motif/analysis.py
+++ b/glycowork/motif/analysis.py
@@ -7,6 +7,7 @@ import statsmodels.api as sm
 import matplotlib.pyplot as plt
 plt.style.use('default')
 from collections import Counter
+from typing import Any
 from scipy.stats import ttest_ind, ttest_rel, norm, levene, f_oneway, spearmanr
 from statsmodels.formula.api import ols
 from statsmodels.stats.multitest import multipletests
@@ -38,9 +39,10 @@ from glycowork.motif.annotate import (annotate_dataset, quantify_motifs, link_fi
 from glycowork.motif.graph import subgraph_isomorphism
 
 
-def preprocess_data(df, group1, group2, experiment = "diff", motifs = False, feature_set = ['exhaustive', 'known'], paired = False,
-                    impute = True, min_samples = 0.1, transform = "CLR", gamma = 0.1, custom_scale = 0, custom_motifs = [],
-                    monte_carlo = False):
+def preprocess_data(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], experiment: str = "diff", motifs: bool = False,
+                   feature_set: list[str] = ['exhaustive', 'known'], paired: bool = False, impute: bool = True, min_samples: float = 0.1,
+                   transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0, custom_motifs: list[str] = [],
+                   monte_carlo: bool = False) -> tuple[pd.DataFrame, pd.DataFrame, list[str | int], list[str | int]]:
   """Preprocesses data for analysis by the functions within .motif.analysis\n
   | Arguments:
   | :-
@@ -112,9 +114,9 @@ def preprocess_data(df, group1, group2, experiment = "diff", motifs = False, fea
   return df, df_org, group1, group2
 
 
-def get_pvals_motifs(df, glycan_col_name = 'glycan', label_col_name = 'target',
-                     zscores = True, thresh = 1.645, sorting = True, feature_set = ['exhaustive'],
-                     multiple_samples = False, motifs = None, custom_motifs = []):
+def get_pvals_motifs(df: pd.DataFrame | str, glycan_col_name: str = 'glycan', label_col_name: str = 'target', zscores: bool = True,
+                     thresh: float = 1.645, sorting: bool = True, feature_set: list[str] = ['exhaustive'], multiple_samples: bool = False,
+                     motifs: pd.DataFrame | None = None, custom_motifs: list[str] = []) -> pd.DataFrame:
     """returns enriched motifs based on label data or predicted data\n
     | Arguments:
     | :-
@@ -180,7 +182,7 @@ def get_pvals_motifs(df, glycan_col_name = 'glycan', label_col_name = 'target',
     return out
 
 
-def get_representative_substructures(enrichment_df):
+def get_representative_substructures(enrichment_df: pd.DataFrame) -> list[str]:
     """builds minimal glycans that contain enriched motifs from get_pvals_motifs\n
     | Arguments:
     | :-
@@ -213,9 +215,9 @@ def get_representative_substructures(enrichment_df):
     return [k for k in rep_motifs if sum(subgraph_isomorphism(j, k) for j in rep_motifs) <= 1]
 
 
-def get_heatmap(df, motifs = False, feature_set = ['known'], transform = '',
-                 datatype = 'response', rarity_filter = 0.05, filepath = '', index_col = 'glycan',
-                custom_motifs = [], return_plot = False, show_all = False, **kwargs):
+def get_heatmap(df: pd.DataFrame | str, motifs: bool = False, feature_set: list[str] = ['known'], transform: str = '', datatype: str = 'response',
+                rarity_filter: float = 0.05, filepath: str = '', index_col: str = 'glycan', custom_motifs: list[str] = [], return_plot: bool = False,
+                show_all: bool = False, **kwargs) -> None | Any:
   """clusters samples based on glycan data (for instance glycan binding etc.)\n
   | Arguments:
   | :-
@@ -289,9 +291,8 @@ def get_heatmap(df, motifs = False, feature_set = ['known'], transform = '',
     plt.show()
 
 
-def plot_embeddings(glycans, emb = None, label_list = None,
-                    shape_feature = None, filepath = '', alpha = 0.8,
-                    palette = 'colorblind', **kwargs):
+def plot_embeddings(glycans: list[str], emb: dict[str, np.ndarray] | pd.DataFrame | None = None, label_list: list[Any] | None = None,
+                   shape_feature: str | None = None, filepath: str = '', alpha: float = 0.8, palette: str = 'colorblind', **kwargs) -> None:
     """plots glycan representations for a list of glycans\n
     | Arguments:
     | :-
@@ -337,8 +338,8 @@ def plot_embeddings(glycans, emb = None, label_list = None,
     plt.show()
 
 
-def characterize_monosaccharide(sugar, df = None, mode = 'sugar', glycan_col_name = 'glycan',
-                                rank = None, focus = None, modifications = False, filepath = '', thresh = 10):
+def characterize_monosaccharide(sugar: str, df: pd.DataFrame | None = None, mode: str = 'sugar', glycan_col_name: str = 'glycan',
+                              rank: str | None = None, focus: str | None = None, modifications: bool = False, filepath: str = '', thresh: int = 10) -> None:
   """for a given monosaccharide/linkage, return typical neighboring linkage/monosaccharide\n
   | Arguments:
   | :-
@@ -440,7 +441,7 @@ def characterize_monosaccharide(sugar, df = None, mode = 'sugar', glycan_col_nam
   plt.show()
 
 
-def get_coverage(df, filepath = ''):
+def get_coverage(df: pd.DataFrame | str, filepath: str = '') -> None:
   """ Plot glycan coverage across samples, ordered by average intensity\n
   | Arguments:
   | :-
@@ -464,9 +465,9 @@ def get_coverage(df, filepath = ''):
   plt.show()
 
 
-def get_pca(df, groups = None, motifs = False, feature_set = ['known', 'exhaustive'],
-            pc_x = 1, pc_y = 2, color = None, shape = None, filepath = '', custom_motifs = [],
-            transform = None, rarity_filter = 0.05):
+def get_pca(df: pd.DataFrame | str, groups: list[int] | pd.DataFrame | None = None, motifs: bool = False, feature_set: list[str] = ['known', 'exhaustive'],
+            pc_x: int = 1, pc_y: int = 2, color: str | None = None, shape: str | None = None, filepath: str = '', custom_motifs: list[str] = [],
+            transform: str | None = None, rarity_filter: float = 0.05) -> None:
   """ PCA plot from glycomics abundance dataframe\n
   | Arguments:
   | :-
@@ -527,7 +528,8 @@ def get_pca(df, groups = None, motifs = False, feature_set = ['known', 'exhausti
   plt.show()
 
 
-def select_grouping(cohort_b, cohort_a, glycans, p_values, paired = False, grouped_BH = False):
+def select_grouping(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, glycans: list[str], p_values: list[float],
+                   paired: bool = False, grouped_BH: bool = False) -> tuple[dict[str, list[str]], dict[str, list[float]]]:
   """test various means of grouping glycans by domain knowledge, to obtain high intra-group correlation\n
   | Arguments:
   | :-
@@ -567,12 +569,11 @@ def select_grouping(cohort_b, cohort_a, glycans, p_values, paired = False, group
   return {"group1": glycans}, {"group1": p_values}
 
 
-def get_differential_expression(df, group1, group2,
-                                motifs = False, feature_set = ['exhaustive', 'known'], paired = False,
-                                impute = True, sets = False, set_thresh = 0.9, effect_size_variance = False,
-                                min_samples = 0.1, grouped_BH = False, custom_motifs = [], transform = None,
-                                gamma = 0.1, custom_scale = 0, glycoproteomics = False, level = 'peptide',
-                                monte_carlo = False):
+def get_differential_expression(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], motifs: bool = False,
+                              feature_set: list[str] = ['exhaustive', 'known'], paired: bool = False, impute: bool = True, sets: bool = False,
+                              set_thresh: float = 0.9, effect_size_variance: bool = False, min_samples: float = 0.1, grouped_BH: bool = False,
+                              custom_motifs: list[str] = [], transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0,
+                              glycoproteomics: bool = False, level: str = 'peptide', monte_carlo: bool = False) -> pd.DataFrame:
   """Calculates differentially expressed glycans or motifs from glycomics data\n
   | Arguments:
   | :-
@@ -704,8 +705,8 @@ def get_differential_expression(df, group1, group2,
     return df_out.dropna().sort_values(by = 'p-val').sort_values(by = 'corr p-val')
 
 
-def get_pval_distribution(df_res, filepath = ''):
-  """ p-value distribution plot of glycan differential expression result\n
+def get_pval_distribution(df_res: pd.DataFrame | str, filepath: str = '') -> None:
+  """p-value distribution plot of glycan differential expression result\n
   | Arguments:
   | :-
   | df_res (dataframe): output from get_differential_expression [alternative: filepath to .csv]
@@ -724,8 +725,8 @@ def get_pval_distribution(df_res, filepath = ''):
   plt.show()
 
 
-def get_ma(df_res, log2fc_thresh = 1, sig_thresh = 0.05, filepath = ''):
-  """ MA plot of glycan differential expression result\n
+def get_ma(df_res: pd.DataFrame | str, log2fc_thresh: int = 1, sig_thresh: float = 0.05, filepath: str = '') -> None:
+  """MA plot of glycan differential expression result\n
   | Arguments:
   | :-
   | df_res (dataframe): output from get_differential_expression [alternative: filepath to .csv or .xlsx]
@@ -752,8 +753,9 @@ def get_ma(df_res, log2fc_thresh = 1, sig_thresh = 0.05, filepath = ''):
   plt.show()
 
 
-def get_volcano(df_res, y_thresh = 0.05, x_thresh = 0, n = None, label_changed = True,
-                x_metric = 'Log2FC', annotate_volcano = False, filepath = '', **kwargs):
+def get_volcano(df_res: pd.DataFrame | str, y_thresh: float = 0.05, x_thresh: float = 0, n: int | None = None,
+                label_changed: bool = True, x_metric: str = 'Log2FC', annotate_volcano: bool = False, filepath: str = '',
+                **kwargs) -> tuple[tuple[str, float], ...] | dict[Any, tuple[str, float]]:
   """Plots glycan differential expression results in a volcano plot\n
   | Arguments:
   | :-
@@ -803,8 +805,9 @@ def get_volcano(df_res, y_thresh = 0.05, x_thresh = 0, n = None, label_changed =
   plt.show()
 
 
-def get_glycanova(df, groups, impute = True, motifs = False, feature_set = ['exhaustive', 'known'],
-                  min_samples = 0.1, posthoc = True, custom_motifs = [], transform = None, gamma = 0.1, custom_scale = 0):
+def get_glycanova(df: pd.DataFrame | str, groups: list[Any], impute: bool = True, motifs: bool = False, feature_set: list[str] = ['exhaustive', 'known'],
+                  min_samples: float = 0.1, posthoc: bool = True, custom_motifs: list[str] = [], transform: str | None = None,
+                  gamma: float = 0.1, custom_scale: float = 0) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
     """Calculate an ANOVA for each glycan (or motif) in the DataFrame\n
     | Arguments:
     | :-
@@ -864,8 +867,8 @@ def get_glycanova(df, groups, impute = True, motifs = False, feature_set = ['exh
     return df_out.sort_values(by = 'corr p-val'), posthoc_results
 
 
-def get_meta_analysis(effect_sizes, variances, model = 'fixed', filepath = '',
-                      study_names = []):
+def get_meta_analysis(effect_sizes: np.ndarray | list[float], variances: np.ndarray | list[float], model: str = 'fixed',
+                     filepath: str = '', study_names: list[str] = []) -> tuple[float, float]:
     """Fixed-effects model or random-effects model for meta-analysis of glycan effect sizes\n
     | Arguments:
     | :-
@@ -930,7 +933,7 @@ def get_meta_analysis(effect_sizes, variances, model = 'fixed', filepath = '',
     return combined_effect_size, p_value
 
 
-def get_glycan_change_over_time(data, degree = 1):
+def get_glycan_change_over_time(data: np.ndarray, degree: int = 1) -> tuple[float | np.ndarray, float]:
     """Tests if the abundance of a glycan changes significantly over time using an OLS model\n
     | Arguments:
     | :-
@@ -959,8 +962,9 @@ def get_glycan_change_over_time(data, degree = 1):
     return coefficients, p_value
 
 
-def get_time_series(df, impute = True, motifs = False, feature_set = ['known', 'exhaustive'], degree = 1,
-                    min_samples = 0.1, custom_motifs = [], transform = None, gamma = 0.1, custom_scale = 0):
+def get_time_series(df: pd.DataFrame | str, impute: bool = True, motifs: bool = False, feature_set: list[str] = ['known', 'exhaustive'],
+                    degree: int = 1, min_samples: float = 0.1, custom_motifs: list[str] = [], transform: str | None = None,
+                    gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
     """Analyzes time series data of glycans using an OLS model\n
     | Arguments:
     | :-
@@ -1025,8 +1029,9 @@ def get_time_series(df, impute = True, motifs = False, feature_set = ['known', '
     return df_out.sort_values(by = 'corr p-val')
 
 
-def get_jtk(df_in, timepoints, periods, interval, motifs = False, feature_set = ['known', 'exhaustive', 'terminal'],
-            custom_motifs = [], transform = None, gamma = 0.1, correction_method = "two-stage"):
+def get_jtk(df_in: pd.DataFrame | str, timepoints: int, periods: list[int], interval: int, motifs: bool = False,
+            feature_set: list[str] = ['known', 'exhaustive', 'terminal'], custom_motifs: list[str] = [], transform: str | None = None,
+            gamma: float = 0.1, correction_method: str = "two-stage") -> pd.DataFrame:
     """Detecting rhythmically expressed glycans via the Jonckheere–Terpstra–Kendall (JTK) algorithm\n
     | Arguments:
     | :-
@@ -1084,8 +1089,9 @@ def get_jtk(df_in, timepoints, periods, interval, motifs = False, feature_set = 
     return df_out.sort_values("Adjusted_P_value")
 
 
-def get_biodiversity(df, group1, group2, metrics = ['alpha', 'beta'], motifs = False, feature_set = ['exhaustive', 'known'],
-                     custom_motifs = [], paired = False, permutations = 999, transform = None, gamma = 0.1, custom_scale = 0):
+def get_biodiversity(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], metrics: list[str] = ['alpha', 'beta'],
+                    motifs: bool = False, feature_set: list[str] = ['exhaustive', 'known'], custom_motifs: list[str] = [], paired: bool = False,
+                    permutations: int = 999, transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """Calculates diversity indices from glycomics data, similar to alpha/beta diversity etc in microbiome data\n
   | Arguments:
   | :-
@@ -1172,8 +1178,9 @@ def get_biodiversity(df, group1, group2, metrics = ['alpha', 'beta'], motifs = F
   return df_out.sort_values(by = 'p-val').sort_values(by = 'corr p-val').reset_index(drop = True)
 
 
-def get_SparCC(df1, df2, motifs = False, feature_set = ["known", "exhaustive"], custom_motifs = [],
-               transform = None, gamma = 0.1, partial_correlations = False):
+def get_SparCC(df1: pd.DataFrame | str, df2: pd.DataFrame | str, motifs: bool = False, feature_set: list[str] = ["known", "exhaustive"],
+               custom_motifs: list[str] = [], transform: str | None = None, gamma: float = 0.1,
+               partial_correlations: bool = False) -> tuple[pd.DataFrame, pd.DataFrame]:
   """Performs SparCC (Sparse Correlations for Compositional Data) on two (glycomics) datasets. Samples should be in the same order.\n
   | Arguments:
   | :-
@@ -1258,7 +1265,7 @@ def get_SparCC(df1, df2, motifs = False, feature_set = ["known", "exhaustive"], 
   return correlation_df, p_value_df
 
 
-def multi_feature_scoring(df, group1, group2, filepath = ''):
+def multi_feature_scoring(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], filepath: str = '') -> tuple[LogisticRegression, float]:
   """Finds the minimal set of glycan features that gives the best model to distinguish conditions\n
   | Arguments:
   | :-
@@ -1302,9 +1309,10 @@ def multi_feature_scoring(df, group1, group2, filepath = ''):
   return model, roc_auc
 
 
-def get_roc(df, group1, group2, motifs = False, feature_set = ["known", "exhaustive"], paired = False, impute = True,
-            min_samples = 0.1, custom_motifs = [], transform = None, gamma = 0.1, custom_scale = 0, filepath = '',
-            multi_score = False):
+def get_roc(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], motifs: bool = False, feature_set: list[str] = ["known", "exhaustive"],
+            paired: bool = False, impute: bool = True, min_samples: float = 0.1, custom_motifs: list[str] = [],
+            transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0, filepath: str = '',
+            multi_score: bool = False) -> list[tuple[str, float]] | dict[str, tuple[str, float]] | tuple[LogisticRegression, float]:
   """Calculates ROC AUC for every feature and, optionally, plots the best\n
   | Arguments:
   | :-
@@ -1399,7 +1407,8 @@ def get_roc(df, group1, group2, motifs = False, feature_set = ["known", "exhaust
   return sorted_auc_scores
 
 
-def get_lectin_array(df, group1, group2, paired = False, transform = ''):
+def get_lectin_array(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int],
+                     paired: bool = False, transform: str = '') -> pd.DataFrame:
   """Function for analyzing lectin array data for two or more groups.\n
   | Arguments:
   | :-
@@ -1468,8 +1477,8 @@ def get_lectin_array(df, group1, group2, paired = False, transform = ''):
   return df_out
 
 
-def get_glycoshift_per_site(df, group1, group2, paired = False, impute = True,
-                            min_samples = 0.2, gamma = 0.1, custom_scale = 0):
+def get_glycoshift_per_site(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], paired: bool = False,
+                           impute: bool = True, min_samples: float = 0.2, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
   """Calculates differentially expressed glycans or motifs from glycoproteomics data\n
   | Arguments:
   | :-

--- a/glycowork/motif/analysis.py
+++ b/glycowork/motif/analysis.py
@@ -1488,7 +1488,7 @@ def get_glycoshift_per_site(df, group1, group2, paired = False, impute = True,
   | (i) Regression coefficient from the GLM (indicating direction of change in the treatment condition)
   | (ii) Corrected p-values (two-tailed t-test with two-stage Benjamini-Hochberg correction) for testing the coefficient against zero
   | (iii) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold"""
-  df, df_org, group1, group2 = preprocess_data(df, group1, group2, experiment = "diff", motifs = False, impute = impute,
+  df, _, group1, group2 = preprocess_data(df, group1, group2, experiment = "diff", motifs = False, impute = impute,
                                                min_samples = min_samples, transform = "Nothing", paired = paired)
   alpha = get_alphaN(len(group1 + group2))
   df, glycan_features = process_for_glycoshift(df)

--- a/glycowork/motif/analysis.py
+++ b/glycowork/motif/analysis.py
@@ -7,7 +7,7 @@ import statsmodels.api as sm
 import matplotlib.pyplot as plt
 plt.style.use('default')
 from collections import Counter
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple, Union
 from scipy.stats import ttest_ind, ttest_rel, norm, levene, f_oneway, spearmanr
 from statsmodels.formula.api import ols
 from statsmodels.stats.multitest import multipletests
@@ -22,7 +22,7 @@ from sklearn.feature_selection import SelectFromModel
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
 
-from glycowork.glycan_data.loader import df_species, unwrap, motif_list, strip_suffixes, download_model
+from glycowork.glycan_data.loader import df_species, unwrap, strip_suffixes, download_model
 from glycowork.glycan_data.stats import (cohen_d, mahalanobis_distance, mahalanobis_variance,
                                          impute_and_normalize, variance_based_filtering,
                                          jtkdist, jtkinit, MissForest, jtkx, get_alphaN, TST_grouped_benjamini_hochberg,
@@ -39,36 +39,23 @@ from glycowork.motif.annotate import (annotate_dataset, quantify_motifs, link_fi
 from glycowork.motif.graph import subgraph_isomorphism
 
 
-def preprocess_data(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], experiment: str = "diff", motifs: bool = False,
-                   feature_set: list[str] = ['exhaustive', 'known'], paired: bool = False, impute: bool = True, min_samples: float = 0.1,
-                   transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0, custom_motifs: list[str] = [],
-                   monte_carlo: bool = False) -> tuple[pd.DataFrame, pd.DataFrame, list[str | int], list[str | int]]:
-  """Preprocesses data for analysis by the functions within .motif.analysis\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of column indices or names for the first group of samples, usually the control (or ANOVA-type group labels)
-  | group2 (list): list of column indices or names for the second group of samples
-  | experiment (string): what kind of experiment to process data for, options are: "diff", "anova"; default:"diff"
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | impute (bool): replaces zeroes with a Random Forest based model; default:True
-  | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
-  | monte_carlo (bool): whether to account for technical variation via Monte Carlo simulations; will be slower and much more conservative; default:False\n
-  | Returns:
-  | :-
-  | (i) transformed and processed dataset
-  | (ii) untransformed but processed dataset
-  | (iii) labels for group1
-  | (iv) labels for group2"""
+def preprocess_data(
+    df: Union[pd.DataFrame, str], # Input dataframe or filepath (.csv/.xlsx)
+    group1: List[Union[str, int]], # Column indices/names for first group
+    group2: List[Union[str, int]], # Column indices/names for second group
+    experiment: str = "diff", # Type of experiment: "diff" or "anova"
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['exhaustive', 'known'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    paired: bool = False, # Whether samples are paired
+    impute: bool = True, # Replace zeros with Random Forest model
+    min_samples: float = 0.1, # Min percent of non-zero samples required
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0, # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    monte_carlo: bool = False # Use Monte Carlo for technical variation
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, List[Union[str, int]], List[Union[str, int]]]: # (transformed df, untransformed df, group1 labels, group2 labels)
+  "Preprocesses glycomics data by handling missing values with Random Forest imputation, applying CLR/ALR transformations to escape compositional bias, and optionally quantifying glycan motifs"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   if not isinstance(group1[0], str) and experiment == "diff":
@@ -114,28 +101,19 @@ def preprocess_data(df: pd.DataFrame | str, group1: list[str | int], group2: lis
   return df, df_org, group1, group2
 
 
-def get_pvals_motifs(df: pd.DataFrame | str, glycan_col_name: str = 'glycan', label_col_name: str = 'target', zscores: bool = True,
-                     thresh: float = 1.645, sorting: bool = True, feature_set: list[str] = ['exhaustive'], multiple_samples: bool = False,
-                     motifs: pd.DataFrame | None = None, custom_motifs: list[str] = []) -> pd.DataFrame:
-    """returns enriched motifs based on label data or predicted data\n
-    | Arguments:
-    | :-
-    | df (dataframe): dataframe containing glycan sequences and labels [alternative: filepath to .csv or .xlsx]
-    | glycan_col_name (string): column name for glycan sequences; arbitrary if multiple_samples = True; default:'glycan'
-    | label_col_name (string): column name for labels; arbitrary if multiple_samples = True; default:'target'
-    | zscores (bool): whether data are presented as z-scores or not, will be z-score transformed if False; default:True
-    | thresh (float): threshold value to separate positive/negative; default is 1.645 for Z-scores
-    | sorting (bool): whether p-value dataframe should be sorted ascendingly; default: True
-    | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-    |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-    |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-    |   and 'chemical' (molecular properties of glycan)
-    | multiple_samples (bool): set to True if you have multiple samples (rows) with glycan information (columns); default:False
-    | motifs (dataframe): can be used to pass a modified motif_list to the function; default:None
-    | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty\n
-    | Returns:
-    | :-
-    | Returns dataframe with p-values, corrected p-values, and Cohen's d as effect size for every glycan motif"""
+def get_pvals_motifs(
+    df: Union[pd.DataFrame, str], # Input dataframe or filepath (.csv/.xlsx)
+    glycan_col_name: str = 'glycan', # Column name for glycan sequences
+    label_col_name: str = 'target', # Column name for labels
+    zscores: bool = True, # Whether data are z-scores
+    thresh: float = 1.645, # Threshold to separate positive/negative
+    sorting: bool = True, # Sort p-value dataframe
+    feature_set: List[str] = ['exhaustive'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    multiple_samples: bool = False, # Multiple samples with glycan columns
+    motifs: Optional[pd.DataFrame] = None, # Modified motif_list
+    custom_motifs: List[str] = [] # Custom motifs if using 'custom' feature set
+    ) -> pd.DataFrame: # DataFrame with p-values, FDR-corrected p-values, and Cohen's d effect sizes for glycan motifs
+    "Identifies significantly enriched glycan motifs using Welch's t-test with FDR correction and Cohen's d effect size calculation, comparing samples above/below threshold"
     if isinstance(df, str):
       df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
     # Reformat to allow for proper annotation in all samples
@@ -182,14 +160,10 @@ def get_pvals_motifs(df: pd.DataFrame | str, glycan_col_name: str = 'glycan', la
     return out
 
 
-def get_representative_substructures(enrichment_df: pd.DataFrame) -> list[str]:
-    """builds minimal glycans that contain enriched motifs from get_pvals_motifs\n
-    | Arguments:
-    | :-
-    | enrichment_df (dataframe): output from get_pvals_motifs\n
-    | Returns:
-    | :-
-    | Returns up to 10 minimal glycans in a list"""
+def get_representative_substructures(
+    enrichment_df: pd.DataFrame # Output from get_pvals_motifs
+    ) -> List[str]: # Up to 10 minimal glycans containing enriched motifs
+    "Constructs minimal glycan structures that represent significantly enriched motifs by optimizing for motif content while minimizing structure size using subgraph isomorphism"
     glycans = list(set(df_species.glycan))
     # Only consider motifs that are significantly enriched
     filtered_df = enrichment_df[enrichment_df.corr_pval < 0.05].reset_index(drop = True)
@@ -215,30 +189,21 @@ def get_representative_substructures(enrichment_df: pd.DataFrame) -> list[str]:
     return [k for k in rep_motifs if sum(subgraph_isomorphism(j, k) for j in rep_motifs) <= 1]
 
 
-def get_heatmap(df: pd.DataFrame | str, motifs: bool = False, feature_set: list[str] = ['known'], transform: str = '', datatype: str = 'response',
-                rarity_filter: float = 0.05, filepath: str = '', index_col: str = 'glycan', custom_motifs: list[str] = [], return_plot: bool = False,
-                show_all: bool = False, **kwargs) -> None | Any:
-  """clusters samples based on glycan data (for instance glycan binding etc.)\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycan data, rows are samples and columns are glycans [alternative: filepath to .csv or .xlsx]
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | transform (string): whether to transform the data before plotting, currently the only option is "CLR", recommended for glycomics data; default: no transformation
-  | datatype (string): whether df comes from a dataset with quantitative variable ('response') or from presence_to_matrix ('presence')
-  | rarity_filter (float): proportion of samples that need to have a non-zero value for a variable to be included; default:0.05
-  | filepath (string): absolute path including full filename allows for saving the plot
-  | index_col (string): default column to convert to dataframe index; default:'glycan'
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | return_plot (bool): whether to return the plot object for external saving; default:False
-  | show_all (bool): whether to plot all ticklabels, no matter how many there are (this might cause visual overlaps); default:False
-  | **kwargs: keyword arguments that are directly passed on to seaborn clustermap\n                      
-  | Returns:
-  | :-
-  | Prints clustermap"""
+def get_heatmap(
+    df: Union[pd.DataFrame, str], # Input dataframe or filepath (.csv/.xlsx)
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['known'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    transform: str = '', # Transform data before plotting
+    datatype: str = 'response', # Data type: 'response' or 'presence'
+    rarity_filter: float = 0.05, # Min proportion for non-zero values
+    filepath: str = '', # Path to save plot
+    index_col: str = 'glycan', # Column to use as index
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    return_plot: bool = False, # Return plot object
+    show_all: bool = False, # Show all tick labels
+    **kwargs: Any # Keyword args passed to seaborn clustermap
+    ) -> Optional[Any]: # None or plot object if return_plot=True
+  "Creates hierarchically clustered heatmap visualization of glycan/motif abundances"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   if index_col in df.columns:
@@ -291,19 +256,17 @@ def get_heatmap(df: pd.DataFrame | str, motifs: bool = False, feature_set: list[
     plt.show()
 
 
-def plot_embeddings(glycans: list[str], emb: dict[str, np.ndarray] | pd.DataFrame | None = None, label_list: list[Any] | None = None,
-                   shape_feature: str | None = None, filepath: str = '', alpha: float = 0.8, palette: str = 'colorblind', **kwargs) -> None:
-    """plots glycan representations for a list of glycans\n
-    | Arguments:
-    | :-
-    | glycans (list): list of IUPAC-condensed glycan sequences as strings
-    | emb (dictionary): stored glycan representations; default takes them from trained species-level SweetNet model
-    | label_list (list): list of same length as glycans if coloring of the plot is desired
-    | shape_feature (string): monosaccharide/bond used to display alternative shapes for dots on the plot
-    | filepath (string): absolute path including full filename allows for saving the plot
-    | alpha (float): transparency of points in plot; default:0.8
-    | palette (string): color palette to color different classes; default:'colorblind'
-    | **kwargs: keyword arguments that are directly passed on to matplotlib\n"""
+def plot_embeddings(
+   glycans: List[str], # List of IUPAC-condensed glycan sequences
+   emb: Optional[Union[Dict[str, np.ndarray], pd.DataFrame]] = None, # Glycan embeddings dict/DataFrame; defaults to SweetNet embeddings
+   label_list: Optional[List[Any]] = None, # Labels for coloring points
+   shape_feature: Optional[str] = None, # Monosaccharide/bond for point shapes
+   filepath: str = '', # Path to save plot
+   alpha: float = 0.8, # Point transparency
+   palette: str = 'colorblind', # Color palette for groups
+   **kwargs: Any # Keyword args passed to seaborn scatterplot
+   ) -> None:
+    "Visualizes learned glycan embeddings using t-SNE dimensionality reduction with optional group coloring"
     idx = [i for i, g in enumerate(glycans) if '{' not in g]
     glycans = [glycans[i] for i in idx]
     label_list = [label_list[i] for i in idx]
@@ -338,23 +301,18 @@ def plot_embeddings(glycans: list[str], emb: dict[str, np.ndarray] | pd.DataFram
     plt.show()
 
 
-def characterize_monosaccharide(sugar: str, df: pd.DataFrame | None = None, mode: str = 'sugar', glycan_col_name: str = 'glycan',
-                              rank: str | None = None, focus: str | None = None, modifications: bool = False, filepath: str = '', thresh: int = 10) -> None:
-  """for a given monosaccharide/linkage, return typical neighboring linkage/monosaccharide\n
-  | Arguments:
-  | :-
-  | sugar (string): monosaccharide or linkage
-  | df (dataframe): dataframe to use for analysis; default:df_species
-  | mode (string): either 'sugar' (connected monosaccharides), 'bond' (monosaccharides making a provided linkage), or 'sugarbond' (linkages that a provided monosaccharides makes); default:'sugar'
-  | glycan_col_name (string): column name under which glycans can be found; default:'glycan'
-  | rank (string): add column name as string if you want to filter for a group
-  | focus (string): add row value as string if you want to filter for a group
-  | modifications (bool): set to True if you want to consider modified versions of a monosaccharide; default:False
-  | filepath (string): absolute path including full filename allows for saving the plot
-  | thresh (int): threshold count of when to include motifs in plot; default:10 occurrences\n
-  | Returns:
-  | :-
-  | Plots modification distribution and typical neighboring bond/monosaccharide"""
+def characterize_monosaccharide(
+    sugar: str, # Monosaccharide or linkage to analyze
+    df: Optional[pd.DataFrame] = None, # DataFrame with glycan column 'glycan'; defaults to df_species
+    mode: str = 'sugar', # Analysis mode: 'sugar', 'bond', 'sugarbond'
+    glycan_col_name: str = 'glycan', # Column name for glycan sequences
+    rank: Optional[str] = None, # Column name for group filtering
+    focus: Optional[str] = None, # Row value for group filtering
+    modifications: bool = False, # Consider modified monosaccharides
+    filepath: str = '', # Path to save plot
+    thresh: int = 10 # Minimum count threshold for inclusion
+    ) -> None:
+  "Analyzes connectivity and modification patterns of specified monosaccharides/linkages in glycan sequences"
   if df is None:
     df = df_species
   if rank is not None and focus is not None:
@@ -441,15 +399,11 @@ def characterize_monosaccharide(sugar: str, df: pd.DataFrame | None = None, mode
   plt.show()
 
 
-def get_coverage(df: pd.DataFrame | str, filepath: str = '') -> None:
-  """ Plot glycan coverage across samples, ordered by average intensity\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | filepath (string): absolute path including full filename allows for saving the plot\n
-  | Returns:
-  | :-
-  | Prints the heatmap"""
+def get_coverage(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1), abundances in columns
+    filepath: str = '' # Path to save plot
+    ) -> None:
+  "Visualizes glycan detection frequency across samples with intensity-based ordering"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   d = df.iloc[:,1:]
@@ -465,31 +419,21 @@ def get_coverage(df: pd.DataFrame | str, filepath: str = '') -> None:
   plt.show()
 
 
-def get_pca(df: pd.DataFrame | str, groups: list[int] | pd.DataFrame | None = None, motifs: bool = False, feature_set: list[str] = ['known', 'exhaustive'],
-            pc_x: int = 1, pc_y: int = 2, color: str | None = None, shape: str | None = None, filepath: str = '', custom_motifs: list[str] = [],
-            transform: str | None = None, rarity_filter: float = 0.05) -> None:
-  """ PCA plot from glycomics abundance dataframe\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | groups (list): a list of group identifiers for each sample (e.g., [1,1,1,2,2,2,3,3,3]); default:None
-  |                     alternatively: design dataframe with 'id' column of samples names and additional columns with meta information
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | pc_x (int): principal component to plot on x axis; default:1
-  | pc_y (int): principal component to plot on y axis; default:2
-  | color (string): if design dataframe is provided: column name for color grouping; default:None
-  | shape (string): if design dataframe is provided: column name for shape grouping; default:None
-  | filepath (string): absolute path including full filename allows for saving the plot
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | transform (string): whether to transform the data before plotting, options are "CLR" and "ALR", recommended for glycomics data; default: no transformation
-  | rarity_filter (float): proportion of samples that need to have a non-zero value for a variable to be included; default:0.05\n
-  | Returns:
-  | :-
-  | Prints PCA plot"""
+def get_pca(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1), abundances in columns
+    groups: Optional[Union[List[int], pd.DataFrame]] = None, # Group labels (e.g., [1,1,1,2,2,2,3,3,3]) or metadata DataFrame with 'id' column
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['known', 'exhaustive'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    pc_x: int = 1, # Principal component for x-axis
+    pc_y: int = 2, # Principal component for y-axis
+    color: Optional[str] = None, # Column in metadata for color grouping
+    shape: Optional[str] = None, # Column in metadata for shape grouping
+    filepath: str = '', # Path to save plot
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    rarity_filter: float = 0.05 # Min proportion for non-zero values
+    ) -> None:
+  "Performs PCA on glycan/motif abundance data with group-based visualization"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   if transform == "ALR":
@@ -528,20 +472,15 @@ def get_pca(df: pd.DataFrame | str, groups: list[int] | pd.DataFrame | None = No
   plt.show()
 
 
-def select_grouping(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, glycans: list[str], p_values: list[float],
-                   paired: bool = False, grouped_BH: bool = False) -> tuple[dict[str, list[str]], dict[str, list[float]]]:
-  """test various means of grouping glycans by domain knowledge, to obtain high intra-group correlation\n
-  | Arguments:
-  | :-
-  | cohort_b (dataframe): dataframe of glycans as rows and samples as columns of the case samples
-  | cohort_a (dataframe): dataframe of glycans as rows and samples as columns of the control samples
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | p_values (list): list of associated p-values
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | grouped_BH (bool): whether to perform two-stage adaptive Benjamini-Hochberg as a grouped multiple testing correction; will SIGNIFICANTLY increase runtime; default:False\n 
-  | Returns:
-  | :-
-  | Returns dictionaries of group : glycans and group : p-values (just one big group if no grouping can be found)"""
+def select_grouping(
+    cohort_b: pd.DataFrame, # Case samples dataframe
+    cohort_a: pd.DataFrame, # Control samples dataframe
+    glycans: List[str], # List of glycans in IUPAC-condensed nomenclature
+    p_values: List[float], # Associated p-values from statistical tests
+    paired: bool = False, # Whether samples are paired
+    grouped_BH: bool = False # Use two-stage adaptive Benjamini-Hochberg
+    ) -> Tuple[Dict[str, List[str]], Dict[str, List[float]]]: # (group:glycans dict, group:p-values dict)
+  "Evaluates optimal glycan grouping strategies (by core type, Sia/Fuc content, or N-glycan type) based on intraclass correlation coefficient, enabling group-aware multiple testing correction"
   if not grouped_BH:
     return {"group1": glycans}, {"group1": p_values}
   funcs = {"by_Sia/Fuc": group_glycans_sia_fuc}
@@ -569,49 +508,28 @@ def select_grouping(cohort_b: pd.DataFrame, cohort_a: pd.DataFrame, glycans: lis
   return {"group1": glycans}, {"group1": p_values}
 
 
-def get_differential_expression(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], motifs: bool = False,
-                              feature_set: list[str] = ['exhaustive', 'known'], paired: bool = False, impute: bool = True, sets: bool = False,
-                              set_thresh: float = 0.9, effect_size_variance: bool = False, min_samples: float = 0.1, grouped_BH: bool = False,
-                              custom_motifs: list[str] = [], transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0,
-                              glycoproteomics: bool = False, level: str = 'peptide', monte_carlo: bool = False) -> pd.DataFrame:
-  """Calculates differentially expressed glycans or motifs from glycomics data\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | impute (bool): replaces zeroes with a Random Forest based model; default:True
-  | sets (bool): whether to identify clusters of highly correlated glycans/motifs to test for differential expression; default:False
-  | set_thresh (float): correlation value used as a threshold for clusters; only used when sets=True; default:0.9
-  | effect_size_variance (bool): whether effect size variance should also be calculated/estimated; default:False
-  | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%
-  | grouped_BH (bool): whether to perform two-stage adaptive Benjamini-Hochberg as a grouped multiple testing correction; will SIGNIFICANTLY increase runtime; default:False
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
-  | glycoproteomics (bool): whether the analyzed data in df comes from a glycoproteomics experiment; default:False
-  | level (string; only relevant if glycoproteomics=True): whether to analyze glycoform differential expression at the level of 'peptide' or 'protein'; default:'peptide'
-  | monte_carlo (bool): whether to account for technical variation via Monte Carlo simulations; will be slower and much more conservative; default:False\n
-  | Returns:
-  | :-
-  | Returns a dataframe with:
-  | (i) Differentially expressed glycans/motifs/sets
-  | (ii) Their mean abundance across all samples in group1 + group2
-  | (iii) Log2-transformed fold change of group2 vs group1 (i.e., negative = lower in group2)
-  | (iv) Uncorrected p-values (Welch's t-test) for difference in mean
-  | (v) Corrected p-values (Welch's t-test with two-stage Benjamini-Hochberg correction) for difference in mean
-  | (vi) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold
-  | (vii) Corrected p-values (Levene's test for equality of variances with Benjamini-Hochberg correction) for difference in variance
-  | (viii) Effect size as Cohen's d (sets=False) or Mahalanobis distance (sets=True)
-  | (xi) Corrected p-values of equivalence test to test whether means are significantly equivalent; only done for p-values > 0.05 from (iv)
-  | (x) [only if effect_size_variance=True] Effect size variance"""
+def get_differential_expression(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1) and abundance values in subsequent columns
+    group1: List[Union[str, int]], # Column indices/names for first group
+    group2: List[Union[str, int]], # Column indices/names for second group
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['exhaustive', 'known'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    paired: bool = False, # Whether samples are paired
+    impute: bool = True, # Replace zeros with Random Forest model
+    sets: bool = False, # Identify clusters of correlated glycans
+    set_thresh: float = 0.9, # Correlation threshold for clusters
+    effect_size_variance: bool = False, # Calculate effect size variance
+    min_samples: float = 0.1, # Min percent of non-zero samples required
+    grouped_BH: bool = False, # Use two-stage adaptive Benjamini-Hochberg
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0, # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    glycoproteomics: bool = False, # Whether data is from glycoproteomics
+    level: str = 'peptide', # Analysis level for glycoproteomics
+    monte_carlo: bool = False # Use Monte Carlo for technical variation
+    ) -> pd.DataFrame: # DataFrame with log2FC, p-values, FDR-corrected p-values, and Cohen's d/Mahalanobis distance effect sizes
+  "Performs differential expression analysis using Welch's t-test (or Hotelling's T2 for sets) with multiple testing correction on glycomics abundance data"
   df, df_org, group1, group2 = preprocess_data(df, group1, group2, experiment = "diff", motifs = motifs, impute = impute,
                                                min_samples = min_samples, transform = transform, feature_set = feature_set,
                                                paired = paired, gamma = gamma, custom_scale = custom_scale, custom_motifs = custom_motifs,
@@ -705,15 +623,11 @@ def get_differential_expression(df: pd.DataFrame | str, group1: list[str | int],
     return df_out.dropna().sort_values(by = 'p-val').sort_values(by = 'corr p-val')
 
 
-def get_pval_distribution(df_res: pd.DataFrame | str, filepath: str = '') -> None:
-  """p-value distribution plot of glycan differential expression result\n
-  | Arguments:
-  | :-
-  | df_res (dataframe): output from get_differential_expression [alternative: filepath to .csv]
-  | filepath (string): absolute path including full filename allows for saving the plot\n
-  | Returns:
-  | :-
-  | prints p-value distribution plot"""
+def get_pval_distribution(
+    df_res: Union[pd.DataFrame, str], # Output DataFrame from get_differential_expression
+    filepath: str = '' # Path to save plot
+    ) -> None:
+  "Creates histogram of p-values from differential expression analysis"
   if isinstance(df_res, str):
     df_res = pd.read_csv(df_res) if df_res.endswith(".csv") else pd.read_excel(df_res)
   # make plot
@@ -725,17 +639,13 @@ def get_pval_distribution(df_res: pd.DataFrame | str, filepath: str = '') -> Non
   plt.show()
 
 
-def get_ma(df_res: pd.DataFrame | str, log2fc_thresh: int = 1, sig_thresh: float = 0.05, filepath: str = '') -> None:
-  """MA plot of glycan differential expression result\n
-  | Arguments:
-  | :-
-  | df_res (dataframe): output from get_differential_expression [alternative: filepath to .csv or .xlsx]
-  | log2fc_thresh (int): absolute Log2FC threshold for highlighting datapoints
-  | sig_thresh (int): significance threshold for highlighting datapoints
-  | filepath (string): absolute path including full filename allows for saving the plot\n
-  | Returns:
-  | :-
-  | prints MA plot"""
+def get_ma(
+    df_res: Union[pd.DataFrame, str], # Output DataFrame from get_differential_expression
+    log2fc_thresh: int = 1, # Log2FC threshold for highlighting
+    sig_thresh: float = 0.05, # Significance threshold for highlighting
+    filepath: str = '' # Path to save plot
+    ) -> None:
+  "Generates MA plot (mean abundance vs log2 fold change) from differential expression results"
   if isinstance(df_res, str):
     df_res = pd.read_csv(df_res) if df_res.endswith(".csv") else pd.read_excel(df_res)
   # Create masks for significant and non-significant points
@@ -753,24 +663,18 @@ def get_ma(df_res: pd.DataFrame | str, log2fc_thresh: int = 1, sig_thresh: float
   plt.show()
 
 
-def get_volcano(df_res: pd.DataFrame | str, y_thresh: float = 0.05, x_thresh: float = 0, n: int | None = None,
-                label_changed: bool = True, x_metric: str = 'Log2FC', annotate_volcano: bool = False, filepath: str = '',
-                **kwargs) -> tuple[tuple[str, float], ...] | dict[Any, tuple[str, float]]:
-  """Plots glycan differential expression results in a volcano plot\n
-  | Arguments:
-  | :-
-  | df_res (dataframe): output from get_differential_expression [alternative: filepath to .csv or .xlsx]
-  | y_thresh (float): corr p threshhold for labeling datapoints; default:0.05
-  | x_thresh (float): absolute x metric threshold for labeling datapoints; default:0
-  | n (float): sample size for Bayesian-Adaptive Alpha Adjustment; default = None
-  | label_changed (bool): if True, add text labels to significantly up- and downregulated datapoints; default:True
-  | x_metric (string): x-axis metric; default:'Log2FC'; options are 'Log2FC', 'Effect size'
-  | annotate_volcano (bool): whether to annotate the dots in the plot with SNFG images; default: False
-  | filepath (string): absolute path including full filename allows for saving the plot
-  | **kwargs: keyword arguments that are directly passed on to seaborn scatterplot\n
-  | Returns:
-  | :-
-  | Prints volcano plot"""
+def get_volcano(
+    df_res: Union[pd.DataFrame, str], # DataFrame from get_differential_expression with columns [Glycan, Log2FC, p-val, corr p-val]
+    y_thresh: float = 0.05, # Corrected p threshold for labeling
+    x_thresh: float = 0, # Absolute x metric threshold for labeling
+    n: Optional[int] = None, # Sample size for Bayesian-Adaptive Alpha
+    label_changed: bool = True, # Add text labels to significant points
+    x_metric: str = 'Log2FC', # x-axis metric: 'Log2FC' or 'Effect size'
+    annotate_volcano: bool = False, # Annotate dots with SNFG images
+    filepath: str = '', # Path to save plot
+    **kwargs: Any # Keyword args passed to seaborn scatterplot
+    ) -> None: # Displays volcano plot
+  "Creates volcano plot showing -log10(FDR-corrected p-values) vs Log2FC or effect size"
   if isinstance(df_res, str):
     df_res = pd.read_csv(df_res) if df_res.endswith(".csv") else pd.read_excel(df_res)
   df_res['log_p'] = -np.log10(df_res['corr p-val'].values)
@@ -805,30 +709,20 @@ def get_volcano(df_res: pd.DataFrame | str, y_thresh: float = 0.05, x_thresh: fl
   plt.show()
 
 
-def get_glycanova(df: pd.DataFrame | str, groups: list[Any], impute: bool = True, motifs: bool = False, feature_set: list[str] = ['exhaustive', 'known'],
-                  min_samples: float = 0.1, posthoc: bool = True, custom_motifs: list[str] = [], transform: str | None = None,
-                  gamma: float = 0.1, custom_scale: float = 0) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
-    """Calculate an ANOVA for each glycan (or motif) in the DataFrame\n
-    | Arguments:
-    | :-
-    | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-    | groups (list): a list of group identifiers for each sample (e.g., [1,1,1,2,2,2,3,3,3])
-    | impute (bool): replaces zeroes with with a Random Forest based model; default:True
-    | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-    | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-    |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-    |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-    |   and 'chemical' (molecular properties of glycan)
-    | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%
-    | posthoc (bool): whether to do Tukey's HSD test post-hoc to find out which differences were significant; default:True
-    | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-    | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-    | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-    | custom_scale (dict): dictionary of type group_idx : mean(group)/min(mean(groups)) for an informed scale model\n
-    | Returns:
-    | :-
-    | (i) a pandas DataFrame with an F statistic, corrected p-value, indication of its significance, and effect size (Omega squared) for each glycan.
-    | (ii) a dictionary of type glycan : pandas DataFrame, with post-hoc results for each glycan with a significant ANOVA."""
+def get_glycanova(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1) and abundance values in columns
+    groups: List[Any], # Group labels for samples (e.g., [1,1,1,2,2,2,3,3,3])
+    impute: bool = True, # Replace zeros with Random Forest model
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['exhaustive', 'known'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    min_samples: float = 0.1, # Min percent of non-zero samples required
+    posthoc: bool = True, # Perform Tukey's HSD test post-hoc
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: float = 0 # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    ) -> Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]: # (ANOVA results with F-stats and omega-squared effect sizes, post-hoc results)
+    "Performs one-way ANOVA with omega-squared effect size calculation and optional Tukey's HSD post-hoc testing on glycomics data across multiple groups"
     df, _, groups, _ = preprocess_data(df, groups, [], experiment = "anova", motifs = motifs, impute = impute,
                                       min_samples = min_samples, transform = transform, feature_set = feature_set,
                                       gamma = gamma, custom_scale = custom_scale, custom_motifs = custom_motifs)
@@ -867,20 +761,14 @@ def get_glycanova(df: pd.DataFrame | str, groups: list[Any], impute: bool = True
     return df_out.sort_values(by = 'corr p-val'), posthoc_results
 
 
-def get_meta_analysis(effect_sizes: np.ndarray | list[float], variances: np.ndarray | list[float], model: str = 'fixed',
-                     filepath: str = '', study_names: list[str] = []) -> tuple[float, float]:
-    """Fixed-effects model or random-effects model for meta-analysis of glycan effect sizes\n
-    | Arguments:
-    | :-
-    | effect_sizes (array-like): Effect sizes (e.g., Cohen's d) from each study
-    | variances (array-like): Corresponding effect size variances from each study
-    | model (string): Whether to use 'fixed' or 'random' effects model
-    | filepath (string): absolute path including full filename allows for saving the Forest plot
-    | study_names (list): list of strings indicating the name of each study\n
-    | Returns:
-    | :-
-    | (1) The combined effect size 
-    | (2) The p-value for the combined effect size"""
+def get_meta_analysis(
+    effect_sizes: Union[np.ndarray, List[float]], # List of Cohen's d/other effect sizes
+    variances: Union[np.ndarray, List[float]], # Associated variance estimates
+    model: str = 'fixed', # 'fixed' or 'random' effects model
+    filepath: str = '', # Path to save Forest plot
+    study_names: List[str] = [] # Names corresponding to each effect size
+    ) -> Tuple[float, float]: # (combined effect size, two-tailed p-value)
+    "Performs fixed/random effects meta-analysis using DerSimonian-Laird method for between-study variance estimation, with optional Forest plot visualization"
     if model not in ['fixed', 'random']:
       raise ValueError("Model must be 'fixed' or 'random'")
     weights = 1 / np.array(variances)
@@ -933,16 +821,11 @@ def get_meta_analysis(effect_sizes: np.ndarray | list[float], variances: np.ndar
     return combined_effect_size, p_value
 
 
-def get_glycan_change_over_time(data: np.ndarray, degree: int = 1) -> tuple[float | np.ndarray, float]:
-    """Tests if the abundance of a glycan changes significantly over time using an OLS model\n
-    | Arguments:
-    | :-
-    | data (numpy array): a 2D numpy array with two columns (time and glycan abundance) and one row per observation
-    | degree (int): degree of the polynomial for regression, default:1 for linear regression\n
-    | Returns:
-    | :-
-    | (i) slope -- the slope of the regression line (i.e., the rate of change of glycan expression over time)
-    | (ii) p_value -- the p-value of the t-test for the slope"""
+def get_glycan_change_over_time(
+    data: np.ndarray, # 2D array with columns [timepoint, abundance]
+    degree: int = 1 # Polynomial degree for regression
+    ) -> Tuple[Union[float, np.ndarray], float]: # (regression coefficients, t-test/F-test p-value)
+    "Fits polynomial regression (default: linear) to glycan abundance time series data using OLS, testing significance of temporal changes"
     # Extract arrays for time and glycan abundance from the 2D input array
     time, glycan_abundance = data[:, 0], data[:, 1]
     if degree == 1:
@@ -962,33 +845,19 @@ def get_glycan_change_over_time(data: np.ndarray, degree: int = 1) -> tuple[floa
     return coefficients, p_value
 
 
-def get_time_series(df: pd.DataFrame | str, impute: bool = True, motifs: bool = False, feature_set: list[str] = ['known', 'exhaustive'],
-                    degree: int = 1, min_samples: float = 0.1, custom_motifs: list[str] = [], transform: str | None = None,
-                    gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-    """Analyzes time series data of glycans using an OLS model\n
-    | Arguments:
-    | :-
-    | df (dataframe): dataframe containing sample IDs of style sampleID_UnitTimepoint_replicate (e.g., T1_h5_r1) in first column and glycan relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-    | impute (bool): replaces zeroes with a Random Forest based model; default:True
-    | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-    | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-    |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-    |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-    |   and 'chemical' (molecular properties of glycan)
-    | degree (int): degree of the polynomial for regression, default:1 for linear regression
-    | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%
-    | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-    | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-    | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-    | custom_scale (dict): dictionary of type timepoint : mean(timepoint)/min(mean(timepoints)) for an informed scale model\n
-    | Returns:
-    | :-
-    | Returns a dataframe with:
-    | (i) Glycans/motifs potentially exhibiting significant changes over time
-    | (ii) The slope of their expression curve over time
-    | (iii) Uncorrected p-values (t-test) for testing whether slope is significantly different from zero
-    | (iv) Corrected p-values (t-test with two-stage Benjamini-Hochberg correction) for testing whether slope is significantly different from zero
-    | (v) Significance: True/False whether the corrected p-value lies below the sample size-appropriate significance threshold"""
+def get_time_series(
+    df: Union[pd.DataFrame, str], # DataFrame with sample IDs as 'sampleID_timepoint_replicate' in col 1 (e.g., T1_h5_r1)
+    impute: bool = True, # Replace zeros with Random Forest model
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['known', 'exhaustive'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    degree: int = 1, # Polynomial degree for regression
+    min_samples: float = 0.1, # Min percent of non-zero samples required
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0 # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    ) -> pd.DataFrame: # DataFrame with regression coefficients and FDR-corrected p-values
+    "Analyzes time series glycomics data using polynomial regression"
     if isinstance(df, str):
       df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
     df = df.fillna(0)
@@ -1029,30 +898,19 @@ def get_time_series(df: pd.DataFrame | str, impute: bool = True, motifs: bool = 
     return df_out.sort_values(by = 'corr p-val')
 
 
-def get_jtk(df_in: pd.DataFrame | str, timepoints: int, periods: list[int], interval: int, motifs: bool = False,
-            feature_set: list[str] = ['known', 'exhaustive', 'terminal'], custom_motifs: list[str] = [], transform: str | None = None,
-            gamma: float = 0.1, correction_method: str = "two-stage") -> pd.DataFrame:
-    """Detecting rhythmically expressed glycans via the Jonckheere–Terpstra–Kendall (JTK) algorithm\n
-    | Arguments:
-    | :-
-    | df_in (pd.DataFrame): A dataframe containing data for analysis. [alternative: filepath to .csv or .xlsx]
-    |   (column 0 = molecule IDs, then arranged in groups and by ascending timepoints)
-    | timepoints (int): number of timepoints in the experiment (each timepoint must have the same number of replicates).
-    | periods (list): number of timepoints (as int) per cycle.
-    | interval (int): units of time (Arbitrary units) between experimental timepoints.
-    | motifs (bool): a flag for running structural of motif-based analysis (True = run motif analysis); default:False.
-    | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-    |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-    |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-    |   and 'chemical' (molecular properties of glycan)
-    | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-    | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-    | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-    | correction_method (string): whether to use "two-stage" or "one-stage" Benjamini-Hochberg for correction; default:"two-stage"\n
-    | Returns:
-    | :-
-    | Returns a pandas dataframe containing the adjusted p-values, and most important waveform parameters for each
-    | molecule in the analysis."""
+def get_jtk(
+   df_in: Union[pd.DataFrame, str], # DataFrame with molecules in rows (col 0), then groups arranged by ascending timepoints
+   timepoints: int, # Number of timepoints (each must have same number of replicates)
+   periods: List[int], # Timepoints per cycle to test
+   interval: int, # Time units between experimental timepoints
+   motifs: bool = False, # Analyze motifs instead of sequences
+   feature_set: List[str] = ['known', 'exhaustive', 'terminal'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+   custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+   transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+   gamma: float = 0.1, # Uncertainty parameter for CLR transform
+   correction_method: str = "two-stage" # Multiple testing correction method
+   ) -> pd.DataFrame: # DataFrame with JTK results: adjusted p-values, period length, lag phase, amplitude
+    "Identifies rhythmically expressed glycans using Jonckheere-Terpstra-Kendall algorithm for time series analysis"
     if isinstance(df_in, str):
       df = pd.read_csv(df_in) if df_in.endswith(".csv") else pd.read_excel(df_in)
     else:
@@ -1089,37 +947,21 @@ def get_jtk(df_in: pd.DataFrame | str, timepoints: int, periods: list[int], inte
     return df_out.sort_values("Adjusted_P_value")
 
 
-def get_biodiversity(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], metrics: list[str] = ['alpha', 'beta'],
-                    motifs: bool = False, feature_set: list[str] = ['exhaustive', 'known'], custom_motifs: list[str] = [], paired: bool = False,
-                    permutations: int = 999, transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """Calculates diversity indices from glycomics data, similar to alpha/beta diversity etc in microbiome data\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): a list of column identifiers corresponding to samples in group 1
-  | group2 (list): a list of column identifiers corresponding to samples in group 2 (note, if an empty list is provided, group 1 can be used a list of group identifiers for each column - e.g., [1,1,2,2,3,3...])
-  | metrics (list): which diversity metrics to calculate (alpha, beta); default:['alpha', 'beta']
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | permutations (int): number of permutations to perform in ANOSIM and PERMANOVA statistical test; default:999
-  | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | Returns a dataframe with:
-  | (i) Diversity indices/metrics
-  | (ii) Mean value of diversity metrics in group 1 (only alpha)
-  | (iii) Mean value of diversity metrics in group 2 (only alpha)
-  | (iv) Uncorrected p-values (Welch's t-test) for difference in mean
-  | (v) Corrected p-values (Welch's t-test with two-stage Benjamini-Hochberg correction) for difference in mean
-  | (vi) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold
-  | (vii) Effect size as Cohen's d (ANOSIM R for beta; F statistics for PERMANOVA and Shannon/Simpson (ANOVA))"""
+def get_biodiversity(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1), abundances in columns
+    group1: List[Union[str, int]], # First group column indices or group labels
+    group2: List[Union[str, int]], # Second group indices or additional group labels
+    metrics: List[str] = ['alpha', 'beta'], # Diversity metrics to calculate
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ['exhaustive', 'known'], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    paired: bool = False, # Whether samples are paired
+    permutations: int = 999, # Number of permutations for ANOSIM/PERMANOVA
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0 # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    ) -> pd.DataFrame: # DataFrame with diversity indices and test statistics
+  "Calculates alpha (Shannon/Simpson) and beta (ANOSIM/PERMANOVA) diversity measures from glycomics data"
   experiment = "diff" if group2 else "anova"
   df, df_org, group1, group2 = preprocess_data(df, group1, group2, experiment = experiment, motifs = motifs, impute = False,
                                                transform = transform, feature_set = feature_set, paired = paired, gamma = gamma,
@@ -1178,27 +1020,17 @@ def get_biodiversity(df: pd.DataFrame | str, group1: list[str | int], group2: li
   return df_out.sort_values(by = 'p-val').sort_values(by = 'corr p-val').reset_index(drop = True)
 
 
-def get_SparCC(df1: pd.DataFrame | str, df2: pd.DataFrame | str, motifs: bool = False, feature_set: list[str] = ["known", "exhaustive"],
-               custom_motifs: list[str] = [], transform: str | None = None, gamma: float = 0.1,
-               partial_correlations: bool = False) -> tuple[pd.DataFrame, pd.DataFrame]:
-  """Performs SparCC (Sparse Correlations for Compositional Data) on two (glycomics) datasets. Samples should be in the same order.\n
-  | Arguments:
-  | :-
-  | df1 (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | df2 (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | partial_correlations (bool): whether to use regularized partial correlations instead (enriches for direct effects); default:False\n
-  | Returns:
-  | :-
-  | Returns (i) a dataframe of pairwise correlations (Spearman's rho)
-  | and (ii) a dataframe with corrected p-values (two-stage Benjamini-Hochberg)"""
+def get_SparCC(
+    df1: Union[pd.DataFrame, str], # First DataFrame with glycans in rows (col 1) and abundances in columns
+    df2: Union[pd.DataFrame, str], # Second DataFrame with same format as df1
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ["known", "exhaustive"], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    partial_correlations: bool = False # Use regularized partial correlations
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]: # (Spearman correlation matrix, FDR-corrected p-value matrix)
+  "Calculates SparCC (Sparse Correlations for Compositional Data) between two matching datasets (e.g., glycomics)"
   if isinstance(df1, str):
     df1 = pd.read_csv(df1) if df1.endswith(".csv") else pd.read_excel(df1)
     df2 = pd.read_csv(df2) if df2.endswith(".csv") else pd.read_excel(df2)
@@ -1265,20 +1097,13 @@ def get_SparCC(df1: pd.DataFrame | str, df2: pd.DataFrame | str, motifs: bool = 
   return correlation_df, p_value_df
 
 
-def multi_feature_scoring(df: pd.DataFrame, group1: list[str | int], group2: list[str | int], filepath: str = '') -> tuple[LogisticRegression, float]:
-  """Finds the minimal set of glycan features that gives the best model to distinguish conditions\n
-  | Arguments:
-  | :-
-  | df (dataframe): transformed dataframe containing glycan sequences in first column and abundances in subsequent columns
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples (note, if an empty list is provided, group 1 can be used a list of group identifiers for each column - e.g., [1,1,2,2,3,3...])
-  | filepath (string): absolute path including full filename allows for saving the plot, if plot=True\n
-  | Returns:
-  | :-
-  | Prints the identified features and returns:
-  | (i) the trained model to distinguish conditions
-  | (ii) the ROC AUC score of the trained model
-  | (iii) (optionally, if filepath) a saved plot of the ROC curve for the model"""
+def multi_feature_scoring(
+    df: pd.DataFrame, # Transformed dataframe with glycans in rows, abundances in columns
+    group1: List[Union[str, int]], # First group indices/names
+    group2: List[Union[str, int]], # Second group indices/names
+    filepath: str = '' # Path to save ROC plot
+    ) -> Tuple[LogisticRegression, float]: # (L1-regularized logistic regression model, ROC AUC score)
+  "Identifies minimal glycan feature set for group classification using L1-regularized logistic regression"
   if group2:
     y = [0] * len(group1) + [1] * len(group2)
   else:
@@ -1309,33 +1134,23 @@ def multi_feature_scoring(df: pd.DataFrame, group1: list[str | int], group2: lis
   return model, roc_auc
 
 
-def get_roc(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], motifs: bool = False, feature_set: list[str] = ["known", "exhaustive"],
-            paired: bool = False, impute: bool = True, min_samples: float = 0.1, custom_motifs: list[str] = [],
-            transform: str | None = None, gamma: float = 0.1, custom_scale: float | dict = 0, filepath: str = '',
-            multi_score: bool = False) -> list[tuple[str, float]] | dict[str, tuple[str, float]] | tuple[LogisticRegression, float]:
-  """Calculates ROC AUC for every feature and, optionally, plots the best\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences in first column and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples (note, if an empty list is provided, group 1 can be used a list of group identifiers for each column - e.g., [1,1,2,2,3,3...])
-  | motifs (bool): whether to analyze full sequences (False) or motifs (True); default:False
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | impute (bool): replaces zeroes with a Random Forest based model; default:True
-  | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 10%
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | transform (str): transformation to escape Aitchison space; options are CLR and ALR (use ALR if you have many glycans (>100) with low values); default:will be inferred
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
-  | filepath (string): absolute path including full filename allows for saving the plot, if plot=True
-  | multi_score (bool): whether to find the best glycan risk score, containing multiple glycan features; default:False\n
-  | Returns:
-  | :-
-  | Returns a sorted list of tuples of type (glycan, AUC score) and, optionally, ROC curve for best feature"""
+def get_roc(
+    df: Union[pd.DataFrame, str], # DataFrame with glycans in rows (col 1), abundances in columns
+    group1: List[Union[str, int]], # First group indices/names
+    group2: List[Union[str, int]], # Second group indices/names
+    motifs: bool = False, # Analyze motifs instead of sequences
+    feature_set: List[str] = ["known", "exhaustive"], # Feature sets to use; exhaustive/known/terminal1/terminal2/terminal3/chemical/graph/custom
+    paired: bool = False, # Whether samples are paired
+    impute: bool = True, # Replace zeros with Random Forest model
+    min_samples: float = 0.1, # Min percent of non-zero samples required
+    custom_motifs: List[str] = [], # Custom motifs if using 'custom' feature set
+    transform: Optional[str] = None, # Transformation type: "CLR" or "ALR"
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0, # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    filepath: str = '', # Path to save ROC plot
+    multi_score: bool = False # Find best multi-glycan score
+    ) -> Union[List[Tuple[str, float]], Dict[Any, Tuple[str, float]], Tuple[LogisticRegression, float]]: # (Feature scores with ROC AUC values)
+  "Calculates ROC curves and AUC scores for glycans/motifs or multi-glycan classifiers"
   experiment = "diff" if group2 else "anova"
   df, _, group1, group2 = preprocess_data(df, group1, group2, experiment = experiment, motifs = motifs, impute = impute,
                                                transform = transform, feature_set = feature_set, paired = paired, gamma = gamma,
@@ -1407,25 +1222,14 @@ def get_roc(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | 
   return sorted_auc_scores
 
 
-def get_lectin_array(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int],
-                     paired: bool = False, transform: str = '') -> pd.DataFrame:
-  """Function for analyzing lectin array data for two or more groups.\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing samples as rows and lectins as columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of indices or names for the first group of samples, usually the control
-  | group2 (list): list of indices or names for the second group of samples (note, if an empty list is provided, group 1 can be used a list of group identifiers for each column - e.g., [1,1,2,2,3,3...])
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | transform (string): optional data-processing, "log2" transforms df with np.log2; default:nothing\n
-  | Returns:
-  | :-
-  | Returns an output dataframe with:
-  | (i) Deduced glycan motifs altered between groups
-  | (ii) human names for features identified in the motifs from (i)
-  | (iii) Lectins supporting the change in (i)
-  | (iv) Direction of the change (e.g., "up" means higher in group2)
-  | (v) Score/Magnitude of the change (remember, if you have more than two groups this reports on any pairwise combination, like an ANOVA)
-  | (vi) Clustering of the scores into highly/moderate/low significance findings"""
+def get_lectin_array(
+    df: Union[pd.DataFrame, str], # DataFrame with samples as rows and lectins as columns, first column containing sample IDs
+    group1: List[Union[str, int]], # First group indices/names
+    group2: List[Union[str, int]], # Second group indices/names
+    paired: bool = False, # Whether samples are paired
+    transform: str = '' # Optional log2 transformation
+    ) -> pd.DataFrame: # DataFrame with altered glycan motifs, supporting lectins, and effect sizes
+  "Analyzes lectin microarray data by mapping lectin binding patterns to glycan motifs, calculating Cohen's d effect sizes between groups and clustering results by significance"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   df = df.set_index(df.columns[0])
@@ -1477,26 +1281,17 @@ def get_lectin_array(df: pd.DataFrame | str, group1: list[str | int], group2: li
   return df_out
 
 
-def get_glycoshift_per_site(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int], paired: bool = False,
-                           impute: bool = True, min_samples: float = 0.2, gamma: float = 0.1, custom_scale: float | dict = 0) -> pd.DataFrame:
-  """Calculates differentially expressed glycans or motifs from glycoproteomics data\n
-  | Arguments:
-  | :-
-  | df (dataframe): glycoproteomics dataset, expects first column to be formatted as protein_site_composition and relative abundances in subsequent columns [alternative: filepath to .csv or .xlsx]
-  | group1 (list): list of column indices or names for the first group of samples, usually the control
-  | group2 (list): list of column indices or names for the second group of samples
-  | paired (bool): whether samples are paired or not (e.g., tumor & tumor-adjacent tissue from same patient); default:False
-  | impute (bool): replaces zeroes with a Random Forest based model; default:True
-  | min_samples (float): Percent of the samples that need to have non-zero values for glycan to be kept; default: 20%
-  | gamma (float): uncertainty parameter to estimate scale uncertainty for CLR transformation; default: 0.1
-  | custom_scale (float or dict): Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)\n
-  | Returns:
-  | :-
-  | Returns a dataframe with:
-  | (for each condition/interaction feature)
-  | (i) Regression coefficient from the GLM (indicating direction of change in the treatment condition)
-  | (ii) Corrected p-values (two-tailed t-test with two-stage Benjamini-Hochberg correction) for testing the coefficient against zero
-  | (iii) Significance: True/False of whether the corrected p-value lies below the sample size-appropriate significance threshold"""
+def get_glycoshift_per_site(
+    df: Union[pd.DataFrame, str], # DataFrame with rows formatted as 'protein_site_composition' in col 1, abundances in remaining cols
+    group1: List[Union[str, int]], # First group indices/names
+    group2: List[Union[str, int]], # Second group indices/names
+    paired: bool = False, # Whether samples are paired
+    impute: bool = True, # Replace zeros with Random Forest model
+    min_samples: float = 0.2, # Min percent of non-zero samples required
+    gamma: float = 0.1, # Uncertainty parameter for CLR transform
+    custom_scale: Union[float, Dict] = 0 # Ratio of total signal in group2/group1 for an informed scale model (or group_idx: mean(group)/min(mean(groups)) signal dict for multivariate)
+    ) -> pd.DataFrame: # DataFrame with GLM coefficients and FDR-corrected p-values
+  "Analyzes site-specific glycosylation changes in glycoproteomics data using generalized linear models (GLM) with compositional data normalization"
   df, _, group1, group2 = preprocess_data(df, group1, group2, experiment = "diff", motifs = False, impute = impute,
                                                min_samples = min_samples, transform = "Nothing", paired = paired)
   alpha = get_alphaN(len(group1 + group2))

--- a/glycowork/motif/annotate.py
+++ b/glycowork/motif/annotate.py
@@ -4,6 +4,7 @@ import numpy as np
 import re
 from collections import defaultdict
 from functools import partial
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from glycowork.glycan_data.loader import linkages, motif_list, find_nth, unwrap, replace_every_second, remove_unmatched_brackets
 from glycowork.motif.graph import subgraph_isomorphism, generate_graph_features, glycan_to_nxGraph, graph_to_string, ensure_graph, possible_topology_check
@@ -11,14 +12,10 @@ from glycowork.motif.processing import IUPAC_to_SMILES, get_lib, find_isomorphs,
 from glycowork.motif.regex import get_match
 
 
-def link_find(glycan: str) -> list[str]:
-  """finds all disaccharide motifs in a glycan sequence using its isomorphs\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns list of unique disaccharides (strings) for a glycan in IUPAC-condensed"""
+def link_find(
+    glycan: str # IUPAC-condensed glycan sequence
+    ) -> List[str]: # List of unique disaccharide motifs
+  "Extracts all disaccharide motifs from a glycan sequence, handling branching and isomorphs"
   if '}' in glycan:
     glycan = glycan[glycan.rindex('}')+1:]
   # Get different string representations of the same glycan
@@ -44,18 +41,13 @@ def link_find(glycan: str) -> list[str]:
   return list(set(coll))
 
 
-def annotate_glycan(glycan: str | nx.Graph, motifs: pd.DataFrame | None = None, 
-                   termini_list: list = [], gmotifs: list[nx.Graph] | None = None) -> pd.DataFrame:
-  """searches for known motifs in glycan sequence\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format (or as networkx graph) that has to contain a floating substituent
-  | motifs (dataframe): dataframe of glycan motifs (name + sequence), can be used with a list of glycans too; default:motif_list
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')
-  | gmotifs (networkx): precalculated motif graphs for speed-up; default:None\n
-  | Returns:
-  | :-
-  | Returns dataframe with counts of motifs in glycan"""
+def annotate_glycan(
+    glycan: Union[str, nx.Graph], # IUPAC-condensed glycan sequence or NetworkX graph
+    motifs: Optional[pd.DataFrame] = None, # Motif dataframe (name + sequence); defaults to motif_list
+    termini_list: List = [], # Monosaccharide positions: 'terminal', 'internal', or 'flexible'
+    gmotifs: Optional[List[nx.Graph]] = None # Precalculated motif graphs for speed
+    ) -> pd.DataFrame: # DataFrame with motif counts for the glycan
+  "Counts occurrences of known motifs in a glycan structure using subgraph isomorphism"
   if motifs is None:
     motifs = motif_list
   # Check whether termini are specified
@@ -76,19 +68,14 @@ def annotate_glycan(glycan: str | nx.Graph, motifs: pd.DataFrame | None = None,
   return out
 
 
-def annotate_glycan_topology_uncertainty(glycan: str | nx.Graph, feasibles: set[str] | None = None, motifs: pd.DataFrame | None = None,
-                                         termini_list: list = [], gmotifs: list[nx.Graph] | None = None) -> pd.DataFrame:
-  """searches for known motifs in glycan sequence\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format (or as networkx graph) that has to contain a floating substituent
-  | feasibles (set): set of glycans in IUPAC-condensed format that are potentially relevant as full topologies; default: mammalian glycans from df_species
-  | motifs (dataframe): dataframe of glycan motifs (name + sequence), can be used with a list of glycans too; default:motif_list
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')
-  | gmotifs (networkx): precalculated motif graphs for speed-up; default:None\n
-  | Returns:
-  | :-
-  | Returns dataframe with counts of motifs in glycan"""
+def annotate_glycan_topology_uncertainty(
+    glycan: Union[str, nx.Graph], # IUPAC-condensed glycan sequence or NetworkX graph
+    feasibles: Optional[Set[str]] = None, # Set of potential full topology glycans; defaults to mammalian glycans
+    motifs: Optional[pd.DataFrame] = None, # Motif dataframe (name + sequence); defaults to motif_list
+    termini_list: List = [], # Monosaccharide positions: 'terminal', 'internal', or 'flexible'
+    gmotifs: Optional[List[nx.Graph]] = None # Precalculated motif graphs for speed
+    ) -> pd.DataFrame: # DataFrame with motif counts considering topology uncertainty
+  "Annotates glycan motifs while handling uncertain topologies by comparing against physiological structures"
   if motifs is None:
     motifs = motif_list
   if feasibles is None:
@@ -125,16 +112,12 @@ def annotate_glycan_topology_uncertainty(glycan: str | nx.Graph, feasibles: set[
   return out
 
 
-def get_molecular_properties(glycan_list: list[str], verbose: bool = False, placeholder: bool = False) -> pd.DataFrame:
-  """given a list of glycans, uses pubchempy to return various molecular parameters retrieved from PubChem\n
-  | Arguments:
-  | :-
-  | glycan_list (list): list of glycans in IUPAC-condensed
-  | verbose (bool): set True to print SMILES not found on PubChem; default:False
-  | placeholder (bool): whether failed requests should return dummy values or be dropped; default:False\n
-  | Returns:
-  | :-
-  | Returns a dataframe with all the molecular parameters retrieved from PubChem"""
+def get_molecular_properties(
+    glycan_list: List[str], # List of IUPAC-condensed glycan sequences
+    verbose: bool = False, # Print SMILES not found on PubChem
+    placeholder: bool = False # Return dummy values instead of dropping failed requests
+    ) -> pd.DataFrame: # DataFrame with molecular parameters from PubChem
+  "Retrieves molecular properties from PubChem for a list of glycans using their SMILES representations"
   try:
     import pubchempy as pcp
   except ImportError:
@@ -172,23 +155,15 @@ def get_molecular_properties(glycan_list: list[str], verbose: bool = False, plac
 
 
 @rescue_glycans
-def annotate_dataset(glycans: list[str], motifs: pd.DataFrame | None = None, feature_set: list[str] = ['known'],
-                     termini_list: list = [], condense: bool = False, custom_motifs: list = []) -> pd.DataFrame:
-  """wrapper function to annotate motifs in list of glycans\n
-  | Arguments:
-  | :-
-  | glycans (list): list of IUPAC-condensed glycan sequences as strings
-  | motifs (dataframe): dataframe of glycan motifs (name + sequence); default:motif_list
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is 'known'; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs of size 1), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), \
-  |   and 'chemical' (molecular properties of glycan)
-  | termini_list (list): list of monosaccharide/linkage positions for motifs (from 'terminal', 'internal', and 'flexible')
-  | condense (bool): if True, throws away columns with only zeroes; default:False
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty\n
-  | Returns:
-  | :-                      
-  | Returns dataframe of glycans (rows) and presence/absence of known motifs (columns)"""
+def annotate_dataset(
+    glycans: List[str], # List of IUPAC-condensed glycan sequences
+    motifs: Optional[pd.DataFrame] = None, # Motif dataframe (name + sequence); defaults to motif_list
+    feature_set: List[str] = ['known'], # Feature types to analyze: known, graph, exhaustive, terminal(1-3), custom, chemical
+    termini_list: List = [], # Monosaccharide positions: 'terminal', 'internal', or 'flexible'
+    condense: bool = False, # Remove columns with only zeros
+    custom_motifs: List = [] # Custom motifs when using 'custom' feature set
+    ) -> pd.DataFrame: # DataFrame mapping glycans to presence/absence of motifs
+  "Comprehensive glycan annotation combining multiple feature types: structural motifs, graph properties, terminal sequences"
   if any([k in ''.join(glycans) for k in [';', '-D-', 'RES', '=']]):
     raise Exception
   invalid_features = set(feature_set) - {'known', 'graph', 'terminal', 'terminal1', 'terminal2', 'terminal3', 'custom', 'chemical', 'exhaustive'}
@@ -264,14 +239,10 @@ def annotate_dataset(glycans: list[str], motifs: pd.DataFrame | None = None, fea
     return pd.concat(shopping_cart, axis = 1)
 
 
-def clean_up_heatmap(df: pd.DataFrame) -> pd.DataFrame:
-  """removes redundant motifs from the dataframe\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycan data, rows are glycan motifs and columns are samples\n
-  | Returns:
-  | :-
-  | Returns a cleaned up dataframe of the same format as the input"""
+def clean_up_heatmap(
+    df: pd.DataFrame # DataFrame with glycan motifs as rows, samples as columns
+    ) -> pd.DataFrame: # DataFrame with redundant motifs removed
+  "Removes redundant motif entries from glycan abundance data while preserving the most informative labels"
   motif_dic = dict(zip(motif_list.motif_name, motif_list.motif))
   df.index = df.index.to_series().apply(lambda x: motif_dic[x] + ' '*20 if x in motif_dic else x)
   # Group the DataFrame by identical rows
@@ -285,21 +256,14 @@ def clean_up_heatmap(df: pd.DataFrame) -> pd.DataFrame:
   return result
 
 
-def quantify_motifs(df: str | pd.DataFrame, glycans: list[str], feature_set: list[str],
-                   custom_motifs: list = [], remove_redundant: bool = True) -> pd.DataFrame:
-  """Extracts and quantifies motifs for a dataset\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing relative abundances (each sample one column) [alternative: filepath to .csv or .xlsx]
-  | glycans(list): glycans as IUPAC-condensed strings
-  | feature_set (list): which feature set to use for annotations, add more to list to expand; default is ['exhaustive','known']; options are: 'known' (hand-crafted glycan features), \
-  |   'graph' (structural graph features of glycans), 'exhaustive' (all mono- and disaccharide features), 'terminal' (non-reducing end motifs), \
-  |   'terminal2' (non-reducing end motifs of size 2), 'terminal3' (non-reducing end motifs of size 3), 'custom' (specify your own motifs in custom_motifs), and 'chemical' (molecular properties of glycan)
-  | custom_motifs (list): list of glycan motifs, used if feature_set includes 'custom'; default:empty
-  | remove_redundant (bool): whether to remove redundant motifs via clean_up_heatmap; default:True\n
-  | Returns:
-  | :-
-  | Returns a pandas DataFrame with motifs as columns and samples as rows"""
+def quantify_motifs(
+   df: Union[str, pd.DataFrame], # DataFrame or filepath with samples as columns, abundances as values
+   glycans: List[str], # List of IUPAC-condensed glycan sequences
+   feature_set: List[str], # Feature types to analyze: known, graph, exhaustive, terminal(1-3), custom, chemical
+   custom_motifs: List = [], # Custom motifs when using 'custom' feature set
+   remove_redundant: bool = True # Remove redundant motifs via clean_up_heatmap
+   ) -> pd.DataFrame: # DataFrame with motif abundances (motifs as columns, samples as rows)
+  "Extracts and quantifies motif abundances from glycan abundance data by weighting motif occurrences"
   if isinstance(df, str):
     df = pd.read_csv(df) if df.endswith(".csv") else pd.read_excel(df)
   # Motif extraction
@@ -323,16 +287,12 @@ def quantify_motifs(df: str | pd.DataFrame, glycans: list[str], feature_set: lis
   return df if not remove_redundant else clean_up_heatmap(df.T)
 
 
-def count_unique_subgraphs_of_size_k(graph: nx.Graph, size: int = 2, terminal: bool = False) -> dict[str, float]:
-  """function to count unique, connected subgraphs of size k (default:disaccharides) occurring in a glycan graph\n
-  | Arguments:
-  | :-
-  | graph (networkx): glycan graph as returned by glycan_to_nxGraph
-  | size (int): number of monosaccharides per -saccharide, default:2 (for disaccharides)
-  | terminal (bool): whether to only count terminal subgraphs; default:False\n
-  | Returns:
-  | :-                   
-  | Returns dictionary of type k-saccharide:count"""
+def count_unique_subgraphs_of_size_k(
+   graph: nx.Graph, # NetworkX graph of a glycan
+   size: int = 2, # Number of monosaccharides per subgraph
+   terminal: bool = False # Only count terminal subgraphs
+   ) -> Dict[str, float]: # Dictionary mapping k-saccharide sequences to counts
+  "Identifies and counts unique connected subgraphs of specified size from glycan structure"
   size = size + (size-1)
   paths = nx.all_pairs_shortest_path(graph, cutoff = size-1)
   labels = nx.get_node_attributes(graph, 'string_labels')
@@ -364,19 +324,14 @@ def count_unique_subgraphs_of_size_k(graph: nx.Graph, size: int = 2, terminal: b
 
 
 @rescue_glycans
-def get_k_saccharides(glycans: list[str], size: int = 2, up_to: bool = False,
-                     just_motifs: bool = False, terminal: bool = False) -> pd.DataFrame | list[list[str]]:
-  """function to retrieve k-saccharides (default:disaccharides) occurring in a list of glycans\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | size (int): number of monosaccharides per -saccharide, default:2 (for disaccharides)
-  | up_to (bool): in theory: include -saccharides up to size k; in practice: include monosaccharides; default:False
-  | just_motifs (bool): if you only want the motifs as a nested list, no dataframe with counts; default:False
-  | terminal (bool): whether to only count terminal subgraphs; default:False\n
-  | Returns:
-  | :-                 
-  | Returns dataframe with k-saccharide counts (columns) for each glycan (rows)"""
+def get_k_saccharides(
+   glycans: List[str], # List of IUPAC-condensed glycan sequences
+   size: int = 2, # Number of monosaccharides per fragment
+   up_to: bool = False, # Include fragments up to size k (adds monosaccharides)
+   just_motifs: bool = False, # Return nested list of motifs instead of count DataFrame
+   terminal: bool = False # Only count terminal fragments
+   ) -> Union[pd.DataFrame, List[List[str]]]: # DataFrame of k-saccharide counts or list of motifs per glycan
+  "Extracts k-saccharide fragments from glycan sequences with options for different fragment sizes and positions"
   if not isinstance(glycans, list):
     raise TypeError("The input has to be a list of glycans")
   if any([k in ''.join(glycans) for k in [';', '-D-', 'RES', '=']]):
@@ -419,16 +374,13 @@ def get_k_saccharides(glycans: list[str], size: int = 2, up_to: bool = False,
       return out_matrix.fillna(0).astype(int)
 
 
-def get_terminal_structures(glycan: str | nx.Graph, size: int = 1) -> list[str]:
-  """returns terminal structures from all non-reducing ends (monosaccharide+linkage)\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed nomenclature or as networkx graph
-  | size (int): how large the extracted motif should be in terms of monosaccharides (for now 1 or 2 are supported; \
-  |   if you want to go higher use get_k_saccharides with terminal = True); default:1\n
-  | Returns:
-  | :-
-  | Returns a list of terminal structures (strings)"""
+def get_terminal_structures(
+   glycan: Union[str, nx.Graph], # IUPAC-condensed glycan sequence or NetworkX graph
+   size: int = 1 # Number of monosaccharides in terminal fragment (1 or 2)
+   ) -> List[str]: # List of terminal structures with linkages
+  "Identifies terminal monosaccharide sequences from non-reducing ends of glycan structure"
+  if size > 2:
+    print("Please use get_k_saccharides with terminal = True for larger terminal structures")
   ggraph = ensure_graph(glycan)
   nodeDict = dict(ggraph.nodes(data = True))
   temp =  [nodeDict[k]['string_labels']+'('+nodeDict[k+1]['string_labels']+')' + \
@@ -438,15 +390,11 @@ def get_terminal_structures(glycan: str | nx.Graph, size: int = 1) -> list[str]:
   return [g.replace('()', '') for g in temp]
 
 
-def create_correlation_network(df: pd.DataFrame, correlation_threshold: float) -> list[set[str]]:
-  """finds clusters of motifs/glycans that correlate to at least the correlation_threshold\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with samples as rows and glycans/motifs as columns
-  | correlation_threshold (float): correlation value used as a threshold for clusters\n
-  | Returns:
-  | :-
-  | Returns a list of sets, which correspond to the glycans/motifs that are put in a cluster"""
+def create_correlation_network(
+   df: pd.DataFrame, # DataFrame with samples as rows, glycans/motifs as columns
+   correlation_threshold: float # Minimum correlation for cluster inclusion
+   ) -> List[Set[str]]: # List of sets containing correlated glycans/motifs
+  "Groups glycans or motifs into clusters based on abundance correlation patterns"
   # Calculate the correlation matrix
   correlation_matrix = df.corr()
   # Create an adjacency matrix based on the correlation threshold
@@ -460,15 +408,11 @@ def create_correlation_network(df: pd.DataFrame, correlation_threshold: float) -
   return clusters
 
 
-def group_glycans_core(glycans: list[str], p_values: list[float]) -> tuple[dict[str, list[str]], dict[str, list[float]]]:
-  """group O-glycans based on core structure\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | p_values (list): list of associated p-values\n
-  | Returns:
-  | :-
-  | Returns dictionaries of group : glycans and group : p-values"""
+def group_glycans_core(
+   glycans: List[str], # List of IUPAC-condensed O-glycan sequences
+   p_values: List[float] # Statistical test p-values for each glycan
+   ) -> Tuple[Dict[str, List[str]], Dict[str, List[float]]]: # (group:glycans dict, group:p-values dict)
+  "Groups O-glycans by core structure (core1, core2, other) for statistical analysis"
   temp = {glycans[k]: p_values[k] for k in range(len(glycans))}
   grouped_glycans, grouped_p_values = {}, {}
   grouped_glycans["core2"] = [g for g in glycans if any([subgraph_isomorphism(g, sub_g) for sub_g in ["GlcNAc(b1-6)GalNAc", "GlcNAcOS(b1-6)GalNAc"]])]
@@ -483,15 +427,11 @@ def group_glycans_core(glycans: list[str], p_values: list[float]) -> tuple[dict[
   return grouped_glycans, grouped_p_values
 
 
-def group_glycans_sia_fuc(glycans: list[str], p_values: list[float]) -> tuple[dict[str, list[str]], dict[str, list[float]]]:
-  """group glycans based on whether they contain sialic acid or fucose\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | p_values (list): list of associated p-values\n
-  | Returns:
-  | :-
-  | Returns dictionaries of group : glycans and group : p-values"""
+def group_glycans_sia_fuc(
+   glycans: List[str], # List of IUPAC-condensed glycan sequences
+   p_values: List[float] # Statistical test p-values for each glycan
+   ) -> Tuple[Dict[str, List[str]], Dict[str, List[float]]]: # (group:glycans dict, group:p-values dict)
+  "Groups glycans by sialic acid and fucose content for statistical analysis"
   temp = {glycans[k]: p_values[k] for k in range(len(glycans))}
   grouped_glycans, grouped_p_values = {}, {}
   grouped_glycans["SiaFuc"] = [g for g in glycans if "Neu" in g and "Fuc" in g]
@@ -509,15 +449,11 @@ def group_glycans_sia_fuc(glycans: list[str], p_values: list[float]) -> tuple[di
   return grouped_glycans, grouped_p_values
 
 
-def group_glycans_N_glycan_type(glycans: list[str], p_values: list[float]) -> tuple[dict[str, list[str]], dict[str, list[float]]]:
-  """group glycans based on complex/hybrid/high-mannose/rest for N-glycans\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed nomenclature
-  | p_values (list): list of associated p-values\n
-  | Returns:
-  | :-
-  | Returns dictionaries of group : glycans and group : p-values"""
+def group_glycans_N_glycan_type(
+   glycans: List[str], # List of IUPAC-condensed N-glycan sequences
+   p_values: List[float] # Statistical test p-values for each glycan
+   ) -> Tuple[Dict[str, List[str]], Dict[str, List[float]]]: # (group:glycans dict, group:p-values dict)
+  "Groups N-glycans by type (complex, hybrid, high-mannose, other) for statistical analysis"
   temp = {glycans[k]: p_values[k] for k in range(len(glycans))}
   grouped_glycans, grouped_p_values = {}, {}
   grouped_glycans["complex"] = [g for g in glycans if any([subgraph_isomorphism(g, sub_g) for sub_g in ["GlcNAc(b1-2)Man(a1-6)", "GlcNAc(b1-2)Man(a1-?)[GlcNAc(b1-2)Man(a1-?)]Man"]])]
@@ -536,9 +472,16 @@ def group_glycans_N_glycan_type(glycans: list[str], p_values: list[float]) -> tu
 
 
 class Lectin():
-  def __init__(self, abbr: list[str], name: list[str],
-               specificity: dict[str, dict[str, list[str]] | None] = {"primary": None, "secondary": None, "negative": None},
-               species: str = "", reference: str = "", notes: str = "") -> None:
+  def __init__(
+       self,
+       abbr: List[str], # List of lectin abbreviations
+       name: List[str], # List of lectin names
+       specificity: Dict[str, Optional[Dict[str, List[str]]]] = {"primary": None, "secondary": None, "negative": None}, # Binding specificity details
+       species: str = "", # Source species
+       reference: str = "", # Literature reference
+       notes: str = "" # Additional information
+       ) -> None:
+    "Lectin object storing binding specificity and annotation information"
     self.abbr = abbr
     self.name = name
     self.species = species
@@ -546,27 +489,29 @@ class Lectin():
     self.notes = notes
     self.specificity = specificity
 
-  def get_all_binding_motifs_count(self) -> int:
+  def get_all_binding_motifs_count(self) -> int: # Total number of binding motifs
+      "Counts total number of primary and secondary binding motifs"
       return len(self.specificity["primary"]) + \
                (len(self.specificity["secondary"]) if self.specificity["secondary"] else 0)
 
-  def get_all_binding_motifs(self) -> list[str]:
+  def get_all_binding_motifs(self) -> List[str]: # List of all binding motifs
+      "Returns combined list of primary and secondary binding motifs"
       return list(self.specificity["primary"].keys()) + list(self.specificity["secondary"].keys())
 
   def show_info(self) -> None:
+      "Displays formatted lectin information including specificities"
       print(f"Name(s): {'; '.join(self.name)}\n"+\
       f"Abbreviation(s): {'; '.join(self.abbr)}\n"+\
       f"Species: {self.species}\n" + \
-                       ''.join(f"Specificity ({key}): {'; '.join(value) if value else 'no information'}\n" 
+                       ''.join(f"Specificity ({key}): {'; '.join(value) if value else 'no information'}\n"
                                for key, value in self.specificity.items()) + \
                        f"Reference: {self.reference}\nnotes: {self.notes}\n")
 
-  def check_binding(self, glycan: str) -> int:
-    """Check whether a glycan binds to this lectin. 
-    Returns an integer. 
-    0: no binding; 
-    1: binds to lectin's primary recognition motif;
-    2: binds to lectin's seconary recognition motif;"""
+  def check_binding(
+       self,
+       glycan: str # IUPAC-condensed glycan sequence
+       ) -> int: # Binding level (0:none, 1:primary, 2:secondary)
+    "Evaluates glycan binding to lectin based on motif recognition"
     for key in ["negative", "primary", "secondary"]:
       motifs = self.specificity.get(key, [])
       if motifs:
@@ -576,11 +521,8 @@ class Lectin():
     return 0
 
 
-def load_lectin_lib() -> dict[int, Lectin]:
-  """create dictionary of lectin specificities for get_lectin_array\n
-  | Returns:
-  | :-
-  | Returns a dictionary of index: Lectin object, with its specificities"""
+def load_lectin_lib() -> Dict[int, Lectin]: # Dictionary mapping indices to Lectin objects
+  "Loads curated lectin library with binding specificity information"
   from glycowork.glycan_data.loader import lectin_specificity
   lectin_lib = {}
   for i, row in enumerate(lectin_specificity.itertuples()):
@@ -590,22 +532,11 @@ def load_lectin_lib() -> dict[int, Lectin]:
   return lectin_lib
 
 
-def create_lectin_and_motif_mappings(lectin_list: list[str], 
-                                   lectin_lib: dict[int, Lectin]) -> tuple[dict[str, int], dict[str, dict[str, int]]]:
-  """Create a collection of lectins that can be used for motif scoring and all possible binding motifs.\n
-  | Arguments:
-  | :-
-  | lectin_list (list): list of lectins used in this experiment
-  | lectin_lib (dict): dictionary of type index : Lectin object\n
-  | Returns:
-  | :-
-  | 1. A useable lectin mapping dictionary that maps a user input lectin (string) to the index of a lectin in library --- {lectin: index}.
-  | 2. A motif mapping dictionary that maps a glycan motif to a dictionary of its corresponding lectins, each of which is assigned a weight class that indicates the level of evidence this lectin provides when scoring for this motif --- {motif: {lectin: weight_class}}.
-  | The weight class depends on the match between the motif and the specificity profile of the lectin.
-  | class 0: exact match between motif and primary specificity
-  | class 1: exact match between motif and secondary specificity
-  | class 2: motif encompasses primary specificity but not negative specificity
-  | class 3: motif encompasses secondary specificity but not negative specificity"""
+def create_lectin_and_motif_mappings(
+   lectin_list: List[str], # List of lectin names/abbreviations
+   lectin_lib: Dict[int, Lectin] # Library of Lectin objects
+   ) -> Tuple[Dict[str, int], Dict[str, Dict[str, int]]]: # (lectin:index dict, motif:{lectin:weight} dict)
+  "Creates mappings between lectins and their recognized motifs with binding strength weights"
   useable_lectin_mapping = {}
   motif_mapping = {}
   lib_lectin_lookup = {i: set(abbr.lower() for abbr in lib_lectin.abbr) for i, lib_lectin in lectin_lib.items()}
@@ -642,23 +573,17 @@ def create_lectin_and_motif_mappings(lectin_list: list[str],
   return useable_lectin_mapping, motif_mapping
 
 
-def lectin_motif_scoring(useable_lectin_mapping: dict[str, int], motif_mapping: dict[str, dict[str, int]], lectin_score_dict: dict[str, float],
-                        lectin_lib: dict[int, Lectin], idf: dict[str, float], class_weight_dict: dict[int, float] = {0: 1, 1: 0.5, 2: 0.5, 3: 0.25},
-                        specificity_weight_dict: dict[str, float] = {"<3": 1, "3-4": 0.75, ">4": 0.5}, duplicate_lectin_penalty_factor: float = 0.8) -> pd.DataFrame:
-  """Scores motifs based on observed lectin binding\n
-  | Arguments:
-  | :-
-  | useable_lectin_mapping (dict): returned from create_lectin_and_motif_mappings()
-  | motif_mapping (dict): returned from create_lectin_and_motif_mappings()
-  | lectin_score_dict (dict): dictionary of type lectin : effect_size
-  | lectin_lib (dict): dictionary of type index : lectin
-  | idf (float): variance of each lectin across groups
-  | class_weight_dict (dict, optional): dictionary of type lectin class : score weighting factor
-  | specificity_weight_dict (dict, optional): dictionary of type binding specificities : penalty weighting factor
-  | duplicate_lectin_penalty_factor (float, optional): penalty for having several of the same lectin; default:0.8\n
-  | Returns:
-  | :-
-  | Returns a dataframe with motifs, supporting lectins, observed change direction, and score"""
+def lectin_motif_scoring(
+   useable_lectin_mapping: Dict[str, int], # Lectin to index mapping
+   motif_mapping: Dict[str, Dict[str, int]], # Motif to {lectin:weight} mapping
+   lectin_score_dict: Dict[str, float], # Lectin effect sizes
+   lectin_lib: Dict[int, Lectin], # Library of Lectin objects
+   idf: Dict[str, float], # Lectin variance across groups
+   class_weight_dict: Dict[int, float] = {0: 1, 1: 0.5, 2: 0.5, 3: 0.25}, # Weights for binding classes
+   specificity_weight_dict: Dict[str, float] = {"<3": 1, "3-4": 0.75, ">4": 0.5}, # Weights for binding specificity
+   duplicate_lectin_penalty_factor: float = 0.8 # Penalty for redundant lectins
+   ) -> pd.DataFrame: # DataFrame with scored motifs and supporting evidence
+  "Calculates weighted motif scores from lectin binding data incorporating specificity and redundancy factors"
   output = []
   useable_lectin_count = {k: list(useable_lectin_mapping.values()).count(v) for k, v in useable_lectin_mapping.items()}
   #max_motifs = max([lectin_lib[k].get_all_binding_motifs_count() for k in useable_lectin_mapping.values()]) + 1

--- a/glycowork/motif/annotate.py
+++ b/glycowork/motif/annotate.py
@@ -214,6 +214,8 @@ def annotate_dataset(glycans, motifs = None, feature_set = ['known'],
       from glycowork.glycan_data.loader import df_species
       feasibles = set(df_species[df_species.Class == "Mammalia"].glycan.values.tolist())
       partial_annotate_topology_uncertainty = partial(annotate_glycan_topology_uncertainty, feasibles = feasibles, motifs = motifs, termini_list = termini_list, gmotifs = gmotifs)
+    else:
+      partial_annotate_topology_uncertainty = partial(annotate_glycan, motifs = motifs, termini_list = termini_list, gmotifs = gmotifs)
     def annotate_switchboard(glycan):
       return partial_annotate_topology_uncertainty(glycan) if glycan.count('{') == 1 else partial_annotate(glycan)
     shopping_cart.append(pd.concat(list(map(annotate_switchboard, glycans)), axis = 0))

--- a/glycowork/motif/draw.py
+++ b/glycowork/motif/draw.py
@@ -5,7 +5,7 @@ from glycowork.motif.tokenization import get_core, get_modification
 from glycowork.motif.processing import min_process_glycans, get_possible_linkages, get_possible_monosaccharides, rescue_glycans, in_lib
 import matplotlib.pyplot as plt
 from io import BytesIO
-from typing import Generator
+from typing import Dict, List, Tuple, Optional, Union, Generator, Any
 import networkx as nx
 import copy
 
@@ -18,22 +18,16 @@ except ImportError:
   raise ImportError("<draw dependencies missing; did you do 'pip install glycowork[draw]'?>")
 import numpy as np
 import pandas as pd
-import sys
 import re
 from math import sin, cos, radians, sqrt, atan, degrees
 
 
-def matches(line: str, opendelim: str = '(', closedelim: str = ')') -> Generator[tuple[int, int, int], None, None]:
-  """Find matching pairs of delimiters in a given string.\n
-  | Arguments:
-  | :-
-  | line (str): The string to search for delimiter pairs.
-  | opendelim (str, optional): The character to use as the opening delimiter. Default: '('.
-  | closedelim (str, optional): The character to use as the closing delimiter. Default: ')'.\n
-  | Returns:
-  | :-
-  | tuple: A tuple containing the start and end positions of the matched delimiter pair, and the current depth of the stack.\n
-  ref: https://stackoverflow.com/questions/5454322/python-how-to-match-nested-parentheses-with-regex"""
+def matches(
+    line: str, # Input string to search
+    opendelim: str = '(', # Opening delimiter
+    closedelim: str = ')' # Closing delimiter
+    ) -> Generator[Tuple[int, int, int], None, None]: # Yields (start pos, end pos, nesting depth)
+  "Finds matching pairs of delimiters in a string, handling nested pairs and returning positions and depth;ref: https://stackoverflow.com/questions/5454322/python-how-to-match-nested-parentheses-with-regex"""
   stack = []
   for m in re.finditer(r'[{}{}]'.format(opendelim, closedelim), line):
       pos = m.start()
@@ -185,13 +179,13 @@ sugar_dict = {
 }
 
 
-def hex_circumference(x_pos: float, y_pos: float, dim: float, col_dict: dict[str, str]) -> None:
-  """Draw a hexagoncircumference at the specified position and dimensions.\n
-  | Arguments:
-  | :-
-  | x_pos (int): X coordinate of the hexagon's center on the drawing canvas.
-  | y_pos (int): Y coordinate of the hexagon's center on the drawing canvas.
-  | dim (int): Arbitrary dimension unit used for scaling the hexagon's size.\n"""
+def hex_circumference(
+    x_pos: float, # X coordinate of hexagon center
+    y_pos: float, # Y coordinate of hexagon center
+    dim: float, # Base dimension for scaling
+    col_dict: Dict[str, str] # Color mapping dictionary
+    ) -> None:
+  "Draws hexagon outline using six connected lines at specified position and scale"
   for i in range(6):
     angle1 = radians(60 * i)
     angle2 = radians(60 * (i + 1))
@@ -205,14 +199,14 @@ def hex_circumference(x_pos: float, y_pos: float, dim: float, col_dict: dict[str
     d.append(p)
 
 
-def hex(x_pos: float, y_pos: float, dim: float, col_dict: dict[str, str], color: str = 'white') -> None:
-  """Draw a hexagon shape at the specified position and dimensions.\n
-  | Arguments:
-  | :-
-  | x_pos (int): X coordinate of the hexagon's center on the drawing canvas.
-  | y_pos (int): Y coordinate of the hexagon's center on the drawing canvas.
-  | dim (int): Arbitrary dimension unit used for scaling the hexagon's size.
-  | color (str): Color of the hexagon. Default is 'white'.\n"""
+def hex(
+    x_pos: float, # X coordinate of hexagon center
+    y_pos: float, # Y coordinate of hexagon center
+    dim: float, # Base dimension for scaling
+    col_dict: Dict[str, str], # Color mapping dictionary
+    color: str = 'white' # Fill color
+    ) -> None:
+  "Draws filled hexagon shape with border at specified position and scale"
   x_base = 0 - x_pos * dim
   y_base = 0 + y_pos * dim
   half_dim = 0.5 * dim
@@ -224,18 +218,21 @@ def hex(x_pos: float, y_pos: float, dim: float, col_dict: dict[str, str], color:
   d.append(draw.Lines(*points, close = True, fill = color, stroke = col_dict['black'], stroke_width = 0.04 * dim))
 
 
-def draw_shape(shape: str, color: str, x_pos: float, y_pos: float, col_dict: dict[str, str], 
-               modification: str = '', dim: float = 50, furanose: bool = False, conf: str = '', 
-               deg: float = 0, text_anchor: str = 'middle', scalar: float = 0) -> None:
-  """draw individual monosaccharides in shapes & colors according to the SNFG nomenclature\n
-  | Arguments:
-  | :-
-  | shape (string): monosaccharide class; shape of icon
-  | color (string): monosaccharide identity; color of icon
-  | x_pos (int): x coordinate of icon on drawing canvas
-  | y_pos (int): y coordinate of icon on drawing canvas
-  | modification (string): icon text annotation; used for post-biosynthetic modifications
-  | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics\n"""
+def draw_shape(
+    shape: str, # SNFG shape designation
+    color: str, # SNFG color designation
+    x_pos: float, # X coordinate of shape center
+    y_pos: float, # Y coordinate of shape center
+    col_dict: Dict[str, str], # Color mapping dictionary
+    modification: str = '', # Text annotation for modifications
+    dim: float = 50, # Base dimension for scaling
+    furanose: bool = False, # Draw furanose indicator
+    conf: str = '', # Ring configuration text
+    deg: float = 0, # Rotation angle in degrees
+    text_anchor: str = 'middle', # Text alignment for postbiosynthetic modifications
+    scalar: float = 0 # Intensity scaling factor for drawsvg output
+    ) -> None:
+  "Draws SNFG glycan symbol with specified shape, color, position and optional annotations"
   x_base = 0 - x_pos * dim
   y_base = 0 + y_pos * dim
   stroke_w = 0.04 * dim
@@ -981,18 +978,17 @@ def draw_shape(shape: str, color: str, x_pos: float, y_pos: float, col_dict: dic
     d.append(draw.Circle(x_base-0.4*dim, y_base, 0.15*dim, fill = 'none', stroke_width = stroke_w, stroke = col_dict['black']))
 
 
-def add_bond(x_start: float, x_stop: float, y_start: float, y_stop: float, label: str = '', dim: float = 50,
-             compact: bool = False, highlight: str = 'show') -> None:
-  """drawing lines (bonds) between start/stop coordinates\n
-  | Arguments:
-  | :-
-  | x_start (int): x1 coordinate
-  | x_stop (int): x2 coordinate
-  | y_start (int): y1 coordinate
-  | y_stop (int): y2 coordinate
-  | label (string): bond text annotation to specify linkage
-  | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics
-  | compact (bool): drawing style; normal or compact\n"""
+def add_bond(
+    x_start: float, # Starting X coordinate
+    x_stop: float, # Ending X coordinate
+    y_start: float, # Starting Y coordinate
+    y_stop: float, # Ending Y coordinate
+    label: str = '', # Bond label text
+    dim: float = 50, # Base dimension for scaling
+    compact: bool = False, # Use compact drawing style
+    highlight: str = 'show' # Highlight state: 'show' or 'hide'
+    ) -> None:
+  "Draws glycosidic bond line with optional label between specified coordinates"
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1012,17 +1008,20 @@ def add_bond(x_start: float, x_stop: float, y_start: float, y_stop: float, label
   d.append(draw.Text(label, dim*0.4, path = p, text_anchor = 'middle', fill = col_dict['black'], valign = 'middle', line_offset = -0.5))
 
 
-def add_sugar(monosaccharide: str, x_pos: float = 0, y_pos: float = 0, modification: str = '', dim: float = 50,
-              compact: bool = False, conf: str = '', deg: float = 0, text_anchor: str = 'middle', highlight: str = 'show', scalar: float = 0) -> None:
-  """wrapper function for drawing monosaccharide at specified position\n
-  | Arguments:
-  | :-
-  | monosaccharide (string): simplified IUPAC nomenclature
-  | x_pos (int): x coordinate of icon on drawing canvas
-  | y_pos (int): y coordinate of icon on drawing canvas
-  | modification (string): icon text annotation; used for post-biosynthetic modifications
-  | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics
-  | compact (bool): drawing style; normal or compact\n"""
+def add_sugar(
+    monosaccharide: str, # IUPAC monosaccharide name
+    x_pos: float = 0, # X coordinate of sugar center
+    y_pos: float = 0, # Y coordinate of sugar center
+    modification: str = '', # Text annotation for modifications
+    dim: float = 50, # Base dimension for scaling
+    compact: bool = False, # Use compact drawing style
+    conf: str = '', # Ring configuration text
+    deg: float = 0, # Rotation angle in degrees
+    text_anchor: str = 'middle', # Text alignment for postbiosynthetic modifications
+    highlight: str = 'show', # Highlight state: 'show' or 'hide'
+    scalar: float = 0 # Intensity scaling factor
+    ) -> None:
+  "Draws SNFG monosaccharide symbol with specified parameters at given position"
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1049,14 +1048,10 @@ def add_sugar(monosaccharide: str, x_pos: float = 0, y_pos: float = 0, modificat
     d.append(p)
 
 
-def multiple_branches(glycan: str) -> str:
-  """Reorder multiple branches by linkage on a given glycan\n
-  | Arguments:
-  | :-
-  | glycan (string): Input glycan string.\n
-  | Returns:
-  | :-
-  | str: Modified glycan string."""
+def multiple_branches(
+    glycan: str # IUPAC-condensed glycan sequence
+    ) -> str: # Reordered glycan sequence
+  "Reorders multiple branches in glycan by linkage positions"
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1076,14 +1071,10 @@ def multiple_branches(glycan: str) -> str:
   return glycan
 
 
-def multiple_branch_branches(glycan: str) -> str:
-  """Reorder nested multiple branches by linkage on a given glycan\n
-  | Arguments:
-  | :-
-  | glycan (str): Input glycan string.\n
-  | Returns:
-  | :-
-  | str: Modified glycan string."""
+def multiple_branch_branches(
+    glycan: str # IUPAC-condensed glycan sequence
+    ) -> str: # Reordered glycan sequence
+  "Reorders nested multiple branches in glycan by linkage positions"
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1093,14 +1084,11 @@ def multiple_branch_branches(glycan: str) -> str:
   return glycan
 
 
-def reorder_for_drawing(glycan: str, by: str = 'linkage') -> str:
-  """order level 0 branches by linkage, ascending\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns re-ordered glycan"""
+def reorder_for_drawing(
+    glycan: str, # IUPAC-condensed glycan sequence
+    by: str = 'linkage' # Ordering criterion: 'linkage' or 'length'
+    ) -> str: # Reordered glycan sequence
+  "Orders level 0 branches ascending by linkage position or length"
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1129,14 +1117,11 @@ def reorder_for_drawing(glycan: str, by: str = 'linkage') -> str:
   return glycan
 
 
-def branch_order(glycan: str, by: str = 'linkage') -> str:
-  """order nested branches by linkage, ascending\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns re-ordered glycan"""
+def branch_order(
+    glycan: str, # IUPAC-condensed glycan sequence
+    by: str = 'linkage' # Ordering criterion: 'linkage' or 'length'
+    ) -> str: # Reordered glycan sequence
+  "Orders nested branches ascending by linkage position or length"
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
   for openpos, closepos, level in matches(tmp):
     if level == 0 and not re.search(r"^Fuc\S{6}$|^Xyl\S{6}$", tmp[openpos:closepos]):
@@ -1161,16 +1146,11 @@ def branch_order(glycan: str, by: str = 'linkage') -> str:
   return glycan
 
 
-def split_node(G: nx.Graph, node: int) -> nx.Graph:
-  """split graph at node\n
-  | Arguments:
-  | :-
-  | G (networkx object): glycan graph
-  | node (int): where to split the graph object\n
-  | Returns:
-  | :-
-  | glycan graph (networkx object), consisting of two disjointed graphs\n
-  ref: https://stackoverflow.com/questions/65853641/networkx-how-to-split-nodes-into-two-effectively-disconnecting-edges"""
+def split_node(
+    G: nx.Graph, # NetworkX glycan graph
+    node: int # Node to split
+    ) -> nx.Graph: # Modified graph with split node
+  "Splits graph at specified node creating disjoint subgraphs;ref: https://stackoverflow.com/questions/65853641/networkx-how-to-split-nodes-into-two-effectively-disconnecting-edges"""
   edges = G.edges(node, data = True)
   new_edges = []
   new_nodes = []
@@ -1187,39 +1167,26 @@ def split_node(G: nx.Graph, node: int) -> nx.Graph:
   return G
 
 
-def unique(sequence: list) -> list:
-  """remove duplicates but keep order\n
-  | Arguments:
-  | :-
-  | sequence (list): \n
-  | Returns:
-  | :-
-  | deduplicated list, preserving original order\n
-  ref: https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order"""
+def unique(
+    sequence: List[Any] # Input sequence with duplicates
+    ) -> List[Any]: # Deduplicated sequence
+  "Removes duplicates while preserving original order;ref: https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order"""
   seen = set()
   return [x for x in sequence if not (x in seen or seen.add(x))]
 
 
-def get_indices(x: list, y: list) -> list[list[int | None]]:
-  """for each element in list x, get index (indices if present multiple times) in list y\n
-  | Arguments:
-  | :-
-  | x (list):
-  | y (list) elements can be lists: \n
-  | Returns:
-  | :-
-  | list of list of indices\n"""
+def get_indices(
+    x: List[Any], # Reference list
+    y: List[Any] # Query list
+    ) -> List[List[Optional[int]]]: # Lists of indices or None
+  "Finds indices of elements from y in x, handling multiple occurrences"
   return [([idx for idx, val in enumerate(x) if val == sub] if sub in x else [None]) for sub in y]
 
 
-def process_bonds(linkage_list: list | list[list]) -> list[str] | list[list[str]]:
-  """prepare linkages for printing to figure\n
-  | Arguments:
-  | :-
-  | linkage_list (list): list (or list of lists) of linkages\n
-  | Returns:
-  | :-
-  | processed linkage_list\n"""
+def process_bonds(
+    linkage_list: Union[List[str], List[List[str]]] # Glycosidic linkages
+    ) -> Union[List[str], List[List[str]]]: # Formatted linkage text
+  "Formats glycosidic linkage text for visualization"
   def process_single_linkage(linkage, regex_dict):
     if '?' in linkage[0] and '?' in linkage[-1]:
         return '?'
@@ -1242,17 +1209,10 @@ def process_bonds(linkage_list: list | list[list]) -> list[str] | list[list[str]
     return [process_single_linkage(linkage, regex_dict) for linkage in linkage_list]
 
 
-def split_monosaccharide_linkage(label_list: list | list[list]) -> tuple[list, list, list]:
-  """Split the monosaccharide linkage and extract relevant information from the given label list.\n
-  | Arguments:
-  | :-
-  | label_list (list): List of labels \n
-  | Returns:
-  | :-
-  | Three lists - sugar, sugar_modification, and bond.
-  |   - sugar (list): List of sugars
-  |   - sugar_modification (list): List of sugar modifications
-  |   - bond (list): List of bond information"""
+def split_monosaccharide_linkage(
+    label_list: Union[List[str], List[List[str]]] # List of monosaccharide-linkage labels
+    ) -> Tuple[List[str], List[str], List[str]]: # (sugars, modifications, bonds)
+  "Separates monosaccharides, modifications and linkages from label strings"
   def process_sublist(sub_list):
     sugar = sub_list[::2][::-1]
     mod = [get_modification(k) if k not in additions else '' for k in sugar]
@@ -1266,14 +1226,10 @@ def split_monosaccharide_linkage(label_list: list | list[list]) -> tuple[list, l
     return process_sublist(label_list)
 
 
-def glycan_to_skeleton(glycan_string: str) -> str:
-  """convert glycan to skeleton of node labels according to the respective glycan graph object\n
-  | Arguments:
-  | :-
-  | glycan_string (string): \n
-  | Returns:
-  | :-
-  | node label skeleton of glycan (string)\n"""
+def glycan_to_skeleton(
+    glycan_string: str # IUPAC-condensed glycan sequence
+    ) -> str: # Node label skeleton
+  "Converts glycan to backbone structure with node indices"
   tmp = multireplace(glycan_string, {'(': ',', ')': ',', '[': ',[,', ']': ',],'})
   elements, idx = [], 0
   for k in filter(bool, tmp.split(',')):
@@ -1285,16 +1241,12 @@ def glycan_to_skeleton(glycan_string: str) -> str:
   return multireplace( '-'.join(elements), {'[-': '[', '-]': ']'})
 
 
-def get_highlight_attribute(glycan_graph: nx.Graph, motif_string: str, termini_list: list = []) -> nx.Graph:
-  '''Label nodes in parent glycan (graph) by presence in motif (string)
-  | Arguments:
-  | :-
-  | glycan_graph (networkx object): Glycan as networkx object.
-  | motif_string (string): Glycan as named motif or in IUPAC-condensed format.
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')\n
-  | Returns:
-  | :-
-  | Returns networkx object of glycan, annotated with the node attribute 'highlight_labels', labeling nodes that constitute the motif ('show') or not ('hide').'''
+def get_highlight_attribute(
+    glycan_graph: nx.Graph, # NetworkX glycan graph
+    motif_string: str, # Motif to highlight
+    termini_list: List = [] # Terminal position specifications
+    ) -> nx.Graph: # Graph with highlight attributes
+  "Labels nodes in glycan graph based on presence in specified motif"
   g1 = glycan_graph
   g_tmp = copy.deepcopy(g1)
   if not motif_string:
@@ -1339,32 +1291,22 @@ def get_highlight_attribute(glycan_graph: nx.Graph, motif_string: str, termini_l
   return g1
 
 
-def process_repeat(repeat: str) -> str:
-  """prepare input for repeat unit\n
-  | Arguments:
-  | :-
-  | repeat (string): Repeat unit in IUPAC-condensed format, terminating either in linkage connecting units or first monosaccharide of the unit\n
-  | Returns:
-  | :-
-  | processed repeat unit in GlycoDraw-ready IUPAC-condensed format"""
+def process_repeat(
+    repeat: str # Repeating unit specification, terminating either in linkage connecting units or first monosaccharide of the unit
+    ) -> str: # Processed repeat unit
+  "Formats repeating unit glycan sequence for drawing"
   backbone = re.findall(r'.*\((?!.*\()', repeat)[0]
   repeat_connection = re.sub(r'\)(.*)', '', re.sub(r'.*\((?!.*\()', '', repeat))
   return 'blank(?1-' + repeat_connection[-1] + ')' + backbone + repeat_connection[:2] + '-?)'
 
 
-def get_coordinates_and_labels(draw_this: str, highlight_motif: str | None, show_linkage: bool = True, 
-                             termini_list: list = []) -> list[list]:
-  """Extract monosaccharide labels and calculate coordinates for drawing\n
-  | Arguments:
-  | :-
-  | draw_this (string): Glycan structure to be drawn.
-  | highlight_motif (string): Glycan as named motif or in IUPAC-condensed format.
-  | show_linkage (bool, optional): Flag indicating whether to show linkages. Default: True.
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')\n
-  | Returns:
-  | :-
-  | data_combined (list of lists)
-  | contains lists with monosaccharide label, x position, y position, modification, bond, conformation"""
+def get_coordinates_and_labels(
+    draw_this: str, # IUPAC-condensed glycan sequence
+    highlight_motif: Optional[str], # Motif to highlight
+    show_linkage: bool = True, # Show linkage labels
+    termini_list: List = [] # Terminal position specifications (from 'terminal', 'internal', and 'flexible')
+) -> List[List]: # Drawing coordinates and labels (monosaccharide label, x position, y position, modification, bond, conformation)
+  "Calculates drawing coordinates and formats labels for glycan visualization"
   if not draw_this.startswith('['):
     draw_this = multiple_branches(multiple_branch_branches(draw_this))
     draw_this = reorder_for_drawing(draw_this)
@@ -1826,15 +1768,15 @@ def get_coordinates_and_labels(draw_this: str, highlight_motif: str | None, show
   return data_combined
 
 
-def draw_bracket(x: float, y_min_max: list[float], direction: str = 'right', 
-                dim: float = 50, highlight: str = 'show', deg: float = 0) -> None:
-  """Draw a bracket shape at the specified position and dimensions.\n
-  | Arguments:
-  | :-
-  | x (int): X coordinate of the bracket on the drawing canvas.
-  | y_min_max (list): List containing the minimum and maximum Y coordinates for the bracket.
-  | direction (string, optional): Direction of the bracket. Possible values are 'right' and 'left'. Default: 'right'.
-  | dim (int, optional): Arbitrary dimension unit used for scaling the bracket's size. Default: 50.\n"""
+def draw_bracket(
+    x: float, # X coordinate
+    y_min_max: List[float], # [Min Y, Max Y] coordinates
+    direction: str = 'right', # Bracket direction ("left", "right")
+    dim: float = 50, # Base dimension for scaling
+    highlight: str = 'show', # Highlight state
+    deg: float = 0 # Rotation angle in degrees
+    ) -> None:
+  "Draws bracket shape at specified position and dimensions"
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1865,6 +1807,7 @@ def draw_bracket(x: float, y_min_max: list[float], direction: str = 'right',
 
 
 def is_jupyter() -> bool:
+  "Detects if code is running in Jupyter notebook environment"
   try:
     from IPython import get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # Check if not in IPython kernel
@@ -1874,7 +1817,10 @@ def is_jupyter() -> bool:
   return True
 
 
-def display_svg_with_matplotlib(svg_data: draw.Drawing) -> None:
+def display_svg_with_matplotlib(
+    svg_data: Any # SVG drawing object
+    ) -> None:
+  "Renders SVG using matplotlib for non-Jupyter environments"
   try:
     from cairosvg import svg2png
   except:
@@ -1891,17 +1837,11 @@ def display_svg_with_matplotlib(svg_data: draw.Drawing) -> None:
   plt.show()
 
 
-def process_per_residue(glycan: str, per_residue: list[float]) -> tuple[list[float], list[list[float]], list[list[float]]]:
-  """Given a glycan and per-residue scalars, will output separate scalar mappings for main, side, and branched side chains\n
-  | Arguments:
-  | :-
-  | glycan (string): Glycan in IUPAC-condensed format.
-  | per_residue (list): list of floats (order should be the same as the monosaccharides in glycan string).\n
-  | Returns:
-  | :-
-  | (i) list of per_residue values for main chain monosaccharides
-  | (ii) nested list of per_residue values for each side chain monosaccharides
-  | (iii) nested list of per_residue values for each branched side chain monosaccharides"""
+def process_per_residue(
+    glycan: str, # IUPAC-condensed glycan sequence
+    per_residue: List[float] # Scalar values per residue
+    ) -> Tuple[List[float], List[List[float]], List[List[float]]]: # (main chain values, side chain values, branched side chain values)
+  "Maps per-residue scalar values to main chain, side chains, and branched side chains"
   temp = re.sub(r'\([^)]*\)', 'x', glycan) + 'x'
   temp = re.sub(r'[^x\[\]]', '', temp)
   main_chain_indices = []
@@ -1963,7 +1903,11 @@ chem_cols_alpha = ['#0385AE', '#0385AE', '#0385AE',     # blue
         '#C23537']                           # red
 
 
-def get_hit_atoms_and_bonds(mol, smt: str) -> tuple[list[int], list[int]]:
+def get_hit_atoms_and_bonds(
+    mol: Any, # RDKit molecule object
+    smt: str # SMARTS pattern string
+    ) -> Tuple[List[int], List[int]]: # (matching atom indices, matching bond indices)
+  "Identifies atoms and bonds matching SMARTS pattern in molecule"
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   try:
     from rdkit.Chem import MolFromSmarts
@@ -1986,7 +1930,14 @@ def get_hit_atoms_and_bonds(mol, smt: str) -> tuple[list[int], list[int]]:
   return alist, blist
 
 
-def add_colours_to_map(els: list[int], cols: dict[int, list], col_num: int, alpha: bool = True, hex: bool = True) -> None:
+def add_colours_to_map(
+    els: List[int], # Element indices
+    cols: Dict[int, List], # Color map dictionary
+    col_num: int, # Color index
+    alpha: bool = True, # Use alpha-adjusted colors
+    hex: bool = True # Return hex color codes
+    ) -> None:
+  "Adds color assignments to mapping dictionary for chemical structure visualization"
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   from matplotlib.colors import ColorConverter
 
@@ -2004,7 +1955,12 @@ def add_colours_to_map(els: list[int], cols: dict[int, list], col_num: int, alph
         cols[el].append(ColorConverter().to_rgb(COLS[col_num]))
 
 
-def draw_chem2d(draw_this: str, mono_list: list[str], filepath: str | None = None):
+def draw_chem2d(
+    draw_this: str, # IUPAC-condensed glycan sequence
+    mono_list: List[str], # List of monosaccharides to highlight
+    filepath: Optional[str] = None # Output file path
+    ) -> Any: # IPython SVG display object
+  "Creates 2D chemical structure drawing with highlighted monosaccharides using RDKit"
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   try:
     from glycowork.motif.processing import IUPAC_to_SMILES
@@ -2060,10 +2016,15 @@ def draw_chem2d(draw_this: str, mono_list: list[str], filepath: str | None = Non
         svg2pdf(bytestring = data, write_to = filepath)
       except:
         raise ImportError("You're missing some draw dependencies. Either use .svg or head to https://bojarlab.github.io/glycowork/examples.html#glycodraw-code-snippets to learn more.")
-  
+
   return SVG(d.GetDrawingText())
 
-def draw_chem3d(draw_this: str, mono_list: list[str], filepath: str | None = None) -> None:
+def draw_chem3d(
+    draw_this: str, # IUPAC-condensed glycan sequence
+    mono_list: List[str], # List of monosaccharides to highlight
+    filepath: Optional[str] = None # Output file path for PDB
+    ) -> None:
+  "Generates 3D chemical structure model with highlighted monosaccharides using RDKit and py3Dmol"
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py and https://github.com/rdkit/rdkit/blob/master/Docs/Book/GettingStartedInPython.rst
   try:
     from glycowork.motif.processing import IUPAC_to_SMILES
@@ -2108,35 +2069,29 @@ def draw_chem3d(draw_this: str, mono_list: list[str], filepath: str | None = Non
       MolToPDBFile(mol, filepath)
     else:
       print("3D structure can only be saved as .pdb file.")
-  
+
   print("Disclaimer: The conformer generated using RDKit and MMFFOptimizeMolecule is not intended to be a replacement for a 'real' conformer analysis tool.")
   v.zoomTo()
   v.show()
 
 
 @rescue_glycans
-def GlycoDraw(draw_this: str, vertical: bool = False, compact: bool = False, 
-              show_linkage: bool = True, dim: float = 50, highlight_motif: str | None = None,
-              highlight_termini_list: list = [], repeat: bool | int | str | None = None,
-              repeat_range: list[int] | None = None, draw_method: str | None = None,
-              filepath: str | None = None, suppress: bool = False,
-              per_residue: list = []) -> draw.Drawing:
-  """Draws a glycan structure based on the provided input.\n
-  | Arguments:
-  | :-
-  | draw_this (string): The glycan structure or motif to be drawn.
-  | vertical (bool, optional): Set to True to draw the structure vertically. Default: False.
-  | compact (bool, optional): Set to True to draw the structure in a compact form. Default: False.
-  | show_linkage (bool, optional): Set to False to hide the linkage information. Default: True.
-  | dim (int, optional): The dimension (size) of the individual sugar units in the structure. Default: 50.
-  | highlight_motif (string, optional): Glycan motif to highlight within the parent structure.
-  | highlight_termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')
-  | repeat (bool | int | str): If specified, indicate repeat unit by brackets (True: n units, int: # of units, str: range of units)
-  | repeat_range (list of 2 int): List of index integers for the first and last main-chain monosaccharide in repeating unit. Monosaccharides are numbered starting from 0 (invisible placeholder = 0 in case of structure terminating in a linkage) at the reducing end.
-  | draw_method (string, optional): Specify 'chem2d' or 'chem3d' to draw chemical structures; default:None (SNFG figure)
-  | filepath (string, optional): The path to the output file to save as SVG or PDF when drawing SNFG/chem2d figures or PDB when generating 3D conformers. Default: None.
-  | suppress (bool, optional): Whether to suppress the visual display of drawings into the console; default:False
-  | per_residue (list, optional): list of floats (order should be the same as the monosaccharides in glycan string) to quantitatively highlight monosaccharides.\n"""
+def GlycoDraw(
+    draw_this: str, # IUPAC-condensed glycan sequence
+    vertical: bool = False, # Draw vertically
+    compact: bool = False, # Use compact style
+    show_linkage: bool = True, # Show linkage labels
+    dim: float = 50, # Base dimension for scaling
+    highlight_motif: Optional[str] = None, # Motif to highlight
+    highlight_termini_list: List = [], # Terminal positions (from 'terminal', 'internal', and 'flexible')
+    repeat: Optional[Union[bool, int, str]] = None, # Repeat unit specification (True: n units, int: # of units, str: range of units)
+    repeat_range: Optional[List[int]] = None, # Repeat unit range
+    draw_method: Optional[str] = None, # Drawing method: None, 'chem2d', 'chem3d'
+    filepath: Optional[str] = None, # Output file path
+    suppress: bool = False, # Suppress display
+    per_residue: List = [] # Per-residue intensity values (order should be the same as the monosaccharides in glycan string)
+    ) -> Any: # Drawing object
+  "Renders glycan structure using SNFG symbols or chemical structure representation"
   if any([k in draw_this for k in [';', '-D-', 'RES', '=']]):
     raise Exception
   if draw_this.startswith('Terminal') and draw_this not in motif_list.motif_name.values.tolist():
@@ -2393,40 +2348,30 @@ def GlycoDraw(draw_this: str, vertical: bool = False, compact: bool = False,
   return d2 if is_jupyter() or suppress or filepath else display_svg_with_matplotlib(d2)
 
 
-def scale_in_range(listy: list[float], a: float, b: float) -> list[float]:
-  """Normalize list of numbers in range a to b\n
-  | Arguments:
-  | :-
-  | listy (list): list of numbers as integers/floats
-  | a (integer/float): min value in normalized range
-  | b (integer/float): max value in normalized range\n
-  | Returns:
-  | :-
-  | Normalized list of numbers"""
+def scale_in_range(
+    listy: List[float], # Numbers to normalize
+    a: float, # Target minimum
+    b: float # Target maximum
+    ) -> List[float]: # Normalized numbers
+  "Normalizes list of numbers to specified range"
   min_val = min(listy)
   max_val = max(listy)
   range_val = max_val - min_val
   return [(b - a) * ((x - min_val) / range_val) + a for x in listy]
 
 
-def annotate_figure(svg_input: str, scale_range: tuple[int, int] = (25, 80), compact: bool = False, glycan_size: str = 'medium',
-                   filepath: str = '', scale_by_DE_res: pd.DataFrame | None = None, x_thresh: float = 1, y_thresh: float = 0.05,
-                   x_metric: str = 'Log2FC') -> str | None:
-  """Modify matplotlib svg figure to replace text labels with glycan figures\n
-  | Arguments:
-  | :-
-  | svg_input (string): absolute path including full filename for input svg figure
-  | scale_range (tuple): tuple of two integers defining min/max glycan dim; default:(25,80)
-  | compact (bool): if True, draw compact glycan figures; default:False
-  | glycan_size (string): modify glycan size; default:'medium'; options are 'small', 'medium', 'large'
-  | filepath (string): absolute path including full filename allows for saving the plot
-  | scale_by_DE_res (df): result table from motif_analysis.get_differential_expression. Include to scale glycan figure size by -10logp
-  | x_thresh (float): absolute x metric threshold for datapoints included for scaling, set to match get_differential_expression; default:1.0
-  | y_thresh (float): corr p threshhold for datapoints included for scaling, set to match get_differential_expression; default:0.05
-  | x_metric (string): x-axis metric; default:'Log2FC'; options are 'Log2FC', 'Effect size'\n
-  | Returns:
-  | :-
-  | Modified figure svg code"""
+def annotate_figure(
+    svg_input: str, # Input SVG file path
+    scale_range: Tuple[int, int] = (25, 80), # Min/max glycan dimensions
+    compact: bool = False, # Use compact style
+    glycan_size: str = 'medium', # Glycan size preset ('small', 'medium', 'large')
+    filepath: str = '', # Output file path
+    scale_by_DE_res: Optional[pd.DataFrame] = None, # Differential expression results (motif_analysis.get_differential_expression)
+    x_thresh: float = 1, # X metric threshold
+    y_thresh: float = 0.05, # P-value threshold
+    x_metric: str = 'Log2FC' # X axis metric ('Log2FC', 'Effect size')
+    ) -> Optional[str]: # Modified SVG code
+  "Replaces text labels with glycan drawings in SVG figure"
   glycan_size_dict = {
       'small': 'scale(0.1 0.1)  translate(0, -74)',
       'medium': 'scale(0.2 0.2)  translate(0, -55)',
@@ -2504,19 +2449,14 @@ def annotate_figure(svg_input: str, scale_range: tuple[int, int] = (25, 80), com
     return svg_tmp
 
 
-def plot_glycans_excel(df: pd.DataFrame | str, folder_filepath: str, glycan_col_num: int = 0,
-                       scaling_factor: float = 0.2, compact: bool = False) -> None:
-  """plots SNFG images of glycans into new column in df and saves df as Excel file\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences [alternative: filepath to .csv or .xlsx]
-  | folder_filepath (string): full filepath to the folder you want to save the output to
-  | glycan_col_num (int): index of the column containing glycan sequences; default:0 (first column)
-  | scaling_factor (float): how large the glycans should be; default:0.2
-  | compact (bool, optional): Set to True to draw the structures in a compact form. Default: False.\n
-  | Returns:
-  | :-
-  | Saves the dataframe with glycan images as output.xlsx into folder_filepath"""
+def plot_glycans_excel(
+    df: Union[pd.DataFrame, str], # DataFrame or filepath with glycans
+    folder_filepath: str, # Output folder path
+    glycan_col_num: int = 0, # Glycan column index
+    scaling_factor: float = 0.2, # Image scaling
+    compact: bool = False # Use compact style
+    ) -> None:
+  "Creates Excel file with SNFG glycan images in a new column"
   try:
     from cairosvg import svg2png
   except:

--- a/glycowork/motif/draw.py
+++ b/glycowork/motif/draw.py
@@ -5,6 +5,7 @@ from glycowork.motif.tokenization import get_core, get_modification
 from glycowork.motif.processing import min_process_glycans, get_possible_linkages, get_possible_monosaccharides, rescue_glycans, in_lib
 import matplotlib.pyplot as plt
 from io import BytesIO
+from typing import Generator
 import networkx as nx
 import copy
 
@@ -22,7 +23,7 @@ import re
 from math import sin, cos, radians, sqrt, atan, degrees
 
 
-def matches(line, opendelim = '(', closedelim = ')'):
+def matches(line: str, opendelim: str = '(', closedelim: str = ')') -> Generator[tuple[int, int, int], None, None]:
   """Find matching pairs of delimiters in a given string.\n
   | Arguments:
   | :-
@@ -32,8 +33,7 @@ def matches(line, opendelim = '(', closedelim = ')'):
   | Returns:
   | :-
   | tuple: A tuple containing the start and end positions of the matched delimiter pair, and the current depth of the stack.\n
-  ref: https://stackoverflow.com/questions/5454322/python-how-to-match-nested-parentheses-with-regex
-  """
+  ref: https://stackoverflow.com/questions/5454322/python-how-to-match-nested-parentheses-with-regex"""
   stack = []
   for m in re.finditer(r'[{}{}]'.format(opendelim, closedelim), line):
       pos = m.start()
@@ -185,17 +185,13 @@ sugar_dict = {
 }
 
 
-def hex_circumference(x_pos, y_pos, dim, col_dict):
+def hex_circumference(x_pos: float, y_pos: float, dim: float, col_dict: dict[str, str]) -> None:
   """Draw a hexagoncircumference at the specified position and dimensions.\n
   | Arguments:
   | :-
   | x_pos (int): X coordinate of the hexagon's center on the drawing canvas.
   | y_pos (int): Y coordinate of the hexagon's center on the drawing canvas.
-  | dim (int): Arbitrary dimension unit used for scaling the hexagon's size.\n
-  | Returns:
-  | :-
-  | None
-  """
+  | dim (int): Arbitrary dimension unit used for scaling the hexagon's size.\n"""
   for i in range(6):
     angle1 = radians(60 * i)
     angle2 = radians(60 * (i + 1))
@@ -209,18 +205,14 @@ def hex_circumference(x_pos, y_pos, dim, col_dict):
     d.append(p)
 
 
-def hex(x_pos, y_pos, dim, col_dict, color = 'white'):
+def hex(x_pos: float, y_pos: float, dim: float, col_dict: dict[str, str], color: str = 'white') -> None:
   """Draw a hexagon shape at the specified position and dimensions.\n
   | Arguments:
   | :-
   | x_pos (int): X coordinate of the hexagon's center on the drawing canvas.
   | y_pos (int): Y coordinate of the hexagon's center on the drawing canvas.
   | dim (int): Arbitrary dimension unit used for scaling the hexagon's size.
-  | color (str): Color of the hexagon. Default is 'white'.\n
-  | Returns:
-  | :-
-  | None
-  """
+  | color (str): Color of the hexagon. Default is 'white'.\n"""
   x_base = 0 - x_pos * dim
   y_base = 0 + y_pos * dim
   half_dim = 0.5 * dim
@@ -232,8 +224,9 @@ def hex(x_pos, y_pos, dim, col_dict, color = 'white'):
   d.append(draw.Lines(*points, close = True, fill = color, stroke = col_dict['black'], stroke_width = 0.04 * dim))
 
 
-def draw_shape(shape, color, x_pos, y_pos, col_dict, modification = '', dim = 50, furanose = False, conf = '', deg = 0, text_anchor = 'middle',
-               scalar = 0):
+def draw_shape(shape: str, color: str, x_pos: float, y_pos: float, col_dict: dict[str, str], 
+               modification: str = '', dim: float = 50, furanose: bool = False, conf: str = '', 
+               deg: float = 0, text_anchor: str = 'middle', scalar: float = 0) -> None:
   """draw individual monosaccharides in shapes & colors according to the SNFG nomenclature\n
   | Arguments:
   | :-
@@ -242,11 +235,7 @@ def draw_shape(shape, color, x_pos, y_pos, col_dict, modification = '', dim = 50
   | x_pos (int): x coordinate of icon on drawing canvas
   | y_pos (int): y coordinate of icon on drawing canvas
   | modification (string): icon text annotation; used for post-biosynthetic modifications
-  | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics\n
-  | Returns:
-  | :-
-  |
-  """
+  | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics\n"""
   x_base = 0 - x_pos * dim
   y_base = 0 + y_pos * dim
   stroke_w = 0.04 * dim
@@ -992,7 +981,8 @@ def draw_shape(shape, color, x_pos, y_pos, col_dict, modification = '', dim = 50
     d.append(draw.Circle(x_base-0.4*dim, y_base, 0.15*dim, fill = 'none', stroke_width = stroke_w, stroke = col_dict['black']))
 
 
-def add_bond(x_start, x_stop, y_start, y_stop, label = '', dim = 50, compact = False, highlight = 'show'):
+def add_bond(x_start: float, x_stop: float, y_start: float, y_stop: float, label: str = '', dim: float = 50,
+             compact: bool = False, highlight: str = 'show') -> None:
   """drawing lines (bonds) between start/stop coordinates\n
   | Arguments:
   | :-
@@ -1002,11 +992,7 @@ def add_bond(x_start, x_stop, y_start, y_stop, label = '', dim = 50, compact = F
   | y_stop (int): y2 coordinate
   | label (string): bond text annotation to specify linkage
   | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics
-  | compact (bool): drawing style; normal or compact\n
-  | Returns:
-  | :-
-  |
-  """
+  | compact (bool): drawing style; normal or compact\n"""
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1026,8 +1012,8 @@ def add_bond(x_start, x_stop, y_start, y_stop, label = '', dim = 50, compact = F
   d.append(draw.Text(label, dim*0.4, path = p, text_anchor = 'middle', fill = col_dict['black'], valign = 'middle', line_offset = -0.5))
 
 
-def add_sugar(monosaccharide, x_pos = 0, y_pos = 0, modification = '', dim = 50, compact = False, conf = '', deg = 0, text_anchor = 'middle', highlight = 'show',
-              scalar = 0):
+def add_sugar(monosaccharide: str, x_pos: float = 0, y_pos: float = 0, modification: str = '', dim: float = 50,
+              compact: bool = False, conf: str = '', deg: float = 0, text_anchor: str = 'middle', highlight: str = 'show', scalar: float = 0) -> None:
   """wrapper function for drawing monosaccharide at specified position\n
   | Arguments:
   | :-
@@ -1036,11 +1022,7 @@ def add_sugar(monosaccharide, x_pos = 0, y_pos = 0, modification = '', dim = 50,
   | y_pos (int): y coordinate of icon on drawing canvas
   | modification (string): icon text annotation; used for post-biosynthetic modifications
   | dim (int): arbitrary dimention unit; necessary for drawsvg; inconsequential when drawing is exported as svg graphics
-  | compact (bool): drawing style; normal or compact\n
-  | Returns:
-  | :-
-  |
-  """
+  | compact (bool): drawing style; normal or compact\n"""
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1067,15 +1049,14 @@ def add_sugar(monosaccharide, x_pos = 0, y_pos = 0, modification = '', dim = 50,
     d.append(p)
 
 
-def multiple_branches(glycan):
+def multiple_branches(glycan: str) -> str:
   """Reorder multiple branches by linkage on a given glycan\n
   | Arguments:
   | :-
   | glycan (string): Input glycan string.\n
   | Returns:
   | :-
-  | str: Modified glycan string.
-  """
+  | str: Modified glycan string."""
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1095,15 +1076,14 @@ def multiple_branches(glycan):
   return glycan
 
 
-def multiple_branch_branches(glycan):
+def multiple_branch_branches(glycan: str) -> str:
   """Reorder nested multiple branches by linkage on a given glycan\n
   | Arguments:
   | :-
   | glycan (str): Input glycan string.\n
   | Returns:
   | :-
-  | str: Modified glycan string.
-  """
+  | str: Modified glycan string."""
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1113,15 +1093,14 @@ def multiple_branch_branches(glycan):
   return glycan
 
 
-def reorder_for_drawing(glycan, by = 'linkage'):
+def reorder_for_drawing(glycan: str, by: str = 'linkage') -> str:
   """order level 0 branches by linkage, ascending\n
   | Arguments:
   | :-
   | glycan (string): glycan in IUPAC-condensed format\n
   | Returns:
   | :-
-  | Returns re-ordered glycan
-  """
+  | Returns re-ordered glycan"""
   if ']' not in glycan:
     return glycan
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
@@ -1150,15 +1129,14 @@ def reorder_for_drawing(glycan, by = 'linkage'):
   return glycan
 
 
-def branch_order(glycan, by = 'linkage'):
+def branch_order(glycan: str, by: str = 'linkage') -> str:
   """order nested branches by linkage, ascending\n
   | Arguments:
   | :-
   | glycan (string): glycan in IUPAC-condensed format\n
   | Returns:
   | :-
-  | Returns re-ordered glycan
-  """
+  | Returns re-ordered glycan"""
   tmp = multireplace(glycan, {'(': '*', ')': '*', '[': '(', ']': ')'})
   for openpos, closepos, level in matches(tmp):
     if level == 0 and not re.search(r"^Fuc\S{6}$|^Xyl\S{6}$", tmp[openpos:closepos]):
@@ -1183,7 +1161,7 @@ def branch_order(glycan, by = 'linkage'):
   return glycan
 
 
-def split_node(G, node):
+def split_node(G: nx.Graph, node: int) -> nx.Graph:
   """split graph at node\n
   | Arguments:
   | :-
@@ -1192,8 +1170,7 @@ def split_node(G, node):
   | Returns:
   | :-
   | glycan graph (networkx object), consisting of two disjointed graphs\n
-  ref: https://stackoverflow.com/questions/65853641/networkx-how-to-split-nodes-into-two-effectively-disconnecting-edges
-  """
+  ref: https://stackoverflow.com/questions/65853641/networkx-how-to-split-nodes-into-two-effectively-disconnecting-edges"""
   edges = G.edges(node, data = True)
   new_edges = []
   new_nodes = []
@@ -1210,7 +1187,7 @@ def split_node(G, node):
   return G
 
 
-def unique(sequence):
+def unique(sequence: list) -> list:
   """remove duplicates but keep order\n
   | Arguments:
   | :-
@@ -1218,13 +1195,12 @@ def unique(sequence):
   | Returns:
   | :-
   | deduplicated list, preserving original order\n
-  ref: https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order
-  """
+  ref: https://stackoverflow.com/questions/480214/how-do-i-remove-duplicates-from-a-list-while-preserving-order"""
   seen = set()
   return [x for x in sequence if not (x in seen or seen.add(x))]
 
 
-def get_indices(x, y):
+def get_indices(x: list, y: list) -> list[list[int | None]]:
   """for each element in list x, get index (indices if present multiple times) in list y\n
   | Arguments:
   | :-
@@ -1232,20 +1208,18 @@ def get_indices(x, y):
   | y (list) elements can be lists: \n
   | Returns:
   | :-
-  | list of list of indices\n
-  """
+  | list of list of indices\n"""
   return [([idx for idx, val in enumerate(x) if val == sub] if sub in x else [None]) for sub in y]
 
 
-def process_bonds(linkage_list):
+def process_bonds(linkage_list: list | list[list]) -> list[str] | list[list[str]]:
   """prepare linkages for printing to figure\n
   | Arguments:
   | :-
   | linkage_list (list): list (or list of lists) of linkages\n
   | Returns:
   | :-
-  | processed linkage_list\n
-  """
+  | processed linkage_list\n"""
   def process_single_linkage(linkage, regex_dict):
     if '?' in linkage[0] and '?' in linkage[-1]:
         return '?'
@@ -1268,7 +1242,7 @@ def process_bonds(linkage_list):
     return [process_single_linkage(linkage, regex_dict) for linkage in linkage_list]
 
 
-def split_monosaccharide_linkage(label_list):
+def split_monosaccharide_linkage(label_list: list | list[list]) -> tuple[list, list, list]:
   """Split the monosaccharide linkage and extract relevant information from the given label list.\n
   | Arguments:
   | :-
@@ -1278,8 +1252,7 @@ def split_monosaccharide_linkage(label_list):
   | Three lists - sugar, sugar_modification, and bond.
   |   - sugar (list): List of sugars
   |   - sugar_modification (list): List of sugar modifications
-  |   - bond (list): List of bond information
-  """
+  |   - bond (list): List of bond information"""
   def process_sublist(sub_list):
     sugar = sub_list[::2][::-1]
     mod = [get_modification(k) if k not in additions else '' for k in sugar]
@@ -1293,15 +1266,14 @@ def split_monosaccharide_linkage(label_list):
     return process_sublist(label_list)
 
 
-def glycan_to_skeleton(glycan_string):
+def glycan_to_skeleton(glycan_string: str) -> str:
   """convert glycan to skeleton of node labels according to the respective glycan graph object\n
   | Arguments:
   | :-
   | glycan_string (string): \n
   | Returns:
   | :-
-  | node label skeleton of glycan (string)\n
-  """
+  | node label skeleton of glycan (string)\n"""
   tmp = multireplace(glycan_string, {'(': ',', ')': ',', '[': ',[,', ']': ',],'})
   elements, idx = [], 0
   for k in filter(bool, tmp.split(',')):
@@ -1313,9 +1285,8 @@ def glycan_to_skeleton(glycan_string):
   return multireplace( '-'.join(elements), {'[-': '[', '-]': ']'})
 
 
-def get_highlight_attribute(glycan_graph, motif_string, termini_list = []):
-  '''
-  Label nodes in parent glycan (graph) by presence in motif (string)
+def get_highlight_attribute(glycan_graph: nx.Graph, motif_string: str, termini_list: list = []) -> nx.Graph:
+  '''Label nodes in parent glycan (graph) by presence in motif (string)
   | Arguments:
   | :-
   | glycan_graph (networkx object): Glycan as networkx object.
@@ -1323,8 +1294,7 @@ def get_highlight_attribute(glycan_graph, motif_string, termini_list = []):
   | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')\n
   | Returns:
   | :-
-  | Returns networkx object of glycan, annotated with the node attribute 'highlight_labels', labeling nodes that constitute the motif ('show') or not ('hide').
-  '''
+  | Returns networkx object of glycan, annotated with the node attribute 'highlight_labels', labeling nodes that constitute the motif ('show') or not ('hide').'''
   g1 = glycan_graph
   g_tmp = copy.deepcopy(g1)
   if not motif_string:
@@ -1369,21 +1339,21 @@ def get_highlight_attribute(glycan_graph, motif_string, termini_list = []):
   return g1
 
 
-def process_repeat(repeat):
+def process_repeat(repeat: str) -> str:
   """prepare input for repeat unit\n
   | Arguments:
   | :-
   | repeat (string): Repeat unit in IUPAC-condensed format, terminating either in linkage connecting units or first monosaccharide of the unit\n
   | Returns:
   | :-
-  | processed repeat unit in GlycoDraw-ready IUPAC-condensed format\n
-  """
+  | processed repeat unit in GlycoDraw-ready IUPAC-condensed format"""
   backbone = re.findall(r'.*\((?!.*\()', repeat)[0]
   repeat_connection = re.sub(r'\)(.*)', '', re.sub(r'.*\((?!.*\()', '', repeat))
   return 'blank(?1-' + repeat_connection[-1] + ')' + backbone + repeat_connection[:2] + '-?)'
 
 
-def get_coordinates_and_labels(draw_this, highlight_motif, show_linkage = True, termini_list = []):
+def get_coordinates_and_labels(draw_this: str, highlight_motif: str | None, show_linkage: bool = True, 
+                             termini_list: list = []) -> list[list]:
   """Extract monosaccharide labels and calculate coordinates for drawing\n
   | Arguments:
   | :-
@@ -1394,8 +1364,7 @@ def get_coordinates_and_labels(draw_this, highlight_motif, show_linkage = True, 
   | Returns:
   | :-
   | data_combined (list of lists)
-  | contains lists with monosaccharide label, x position, y position, modification, bond, conformation
-  """
+  | contains lists with monosaccharide label, x position, y position, modification, bond, conformation"""
   if not draw_this.startswith('['):
     draw_this = multiple_branches(multiple_branch_branches(draw_this))
     draw_this = reorder_for_drawing(draw_this)
@@ -1857,18 +1826,15 @@ def get_coordinates_and_labels(draw_this, highlight_motif, show_linkage = True, 
   return data_combined
 
 
-def draw_bracket(x, y_min_max, direction = 'right', dim = 50,  highlight = 'show', deg = 0):
+def draw_bracket(x: float, y_min_max: list[float], direction: str = 'right', 
+                dim: float = 50, highlight: str = 'show', deg: float = 0) -> None:
   """Draw a bracket shape at the specified position and dimensions.\n
   | Arguments:
   | :-
   | x (int): X coordinate of the bracket on the drawing canvas.
   | y_min_max (list): List containing the minimum and maximum Y coordinates for the bracket.
   | direction (string, optional): Direction of the bracket. Possible values are 'right' and 'left'. Default: 'right'.
-  | dim (int, optional): Arbitrary dimension unit used for scaling the bracket's size. Default: 50.\n
-  | Returns:
-  | :-
-  | None
-  """
+  | dim (int, optional): Arbitrary dimension unit used for scaling the bracket's size. Default: 50.\n"""
   if highlight == 'hide':
     col_dict = col_dict_transparent
   else:
@@ -1898,7 +1864,7 @@ def draw_bracket(x, y_min_max, direction = 'right', dim = 50,  highlight = 'show
   d.append(g)
 
 
-def is_jupyter():
+def is_jupyter() -> bool:
   try:
     from IPython import get_ipython
     if 'IPKernelApp' not in get_ipython().config:  # Check if not in IPython kernel
@@ -1908,7 +1874,7 @@ def is_jupyter():
   return True
 
 
-def display_svg_with_matplotlib(svg_data):
+def display_svg_with_matplotlib(svg_data: draw.Drawing) -> None:
   try:
     from cairosvg import svg2png
   except:
@@ -1925,7 +1891,7 @@ def display_svg_with_matplotlib(svg_data):
   plt.show()
 
 
-def process_per_residue(glycan, per_residue):
+def process_per_residue(glycan: str, per_residue: list[float]) -> tuple[list[float], list[list[float]], list[list[float]]]:
   """Given a glycan and per-residue scalars, will output separate scalar mappings for main, side, and branched side chains\n
   | Arguments:
   | :-
@@ -1935,8 +1901,7 @@ def process_per_residue(glycan, per_residue):
   | :-
   | (i) list of per_residue values for main chain monosaccharides
   | (ii) nested list of per_residue values for each side chain monosaccharides
-  | (iii) nested list of per_residue values for each branched side chain monosaccharides
-  """
+  | (iii) nested list of per_residue values for each branched side chain monosaccharides"""
   temp = re.sub(r'\([^)]*\)', 'x', glycan) + 'x'
   temp = re.sub(r'[^x\[\]]', '', temp)
   main_chain_indices = []
@@ -1998,7 +1963,7 @@ chem_cols_alpha = ['#0385AE', '#0385AE', '#0385AE',     # blue
         '#C23537']                           # red
 
 
-def get_hit_atoms_and_bonds(mol, smt):
+def get_hit_atoms_and_bonds(mol, smt: str) -> tuple[list[int], list[int]]:
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   try:
     from rdkit.Chem import MolFromSmarts
@@ -2021,7 +1986,7 @@ def get_hit_atoms_and_bonds(mol, smt):
   return alist, blist
 
 
-def add_colours_to_map(els, cols, col_num, alpha = True, hex = True):
+def add_colours_to_map(els: list[int], cols: dict[int, list], col_num: int, alpha: bool = True, hex: bool = True) -> None:
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   from matplotlib.colors import ColorConverter
 
@@ -2039,7 +2004,7 @@ def add_colours_to_map(els, cols, col_num, alpha = True, hex = True):
         cols[el].append(ColorConverter().to_rgb(COLS[col_num]))
 
 
-def draw_chem2d(draw_this, mono_list, filepath = None):
+def draw_chem2d(draw_this: str, mono_list: list[str], filepath: str | None = None):
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py
   try:
     from glycowork.motif.processing import IUPAC_to_SMILES
@@ -2098,7 +2063,7 @@ def draw_chem2d(draw_this, mono_list, filepath = None):
   
   return SVG(d.GetDrawingText())
 
-def draw_chem3d(draw_this, mono_list, filepath = None):
+def draw_chem3d(draw_this: str, mono_list: list[str], filepath: str | None = None) -> None:
   # Adapted from https://github.com/rdkit/rdkit/blob/master/Docs/Book/data/test_multi_colours.py and https://github.com/rdkit/rdkit/blob/master/Docs/Book/GettingStartedInPython.rst
   try:
     from glycowork.motif.processing import IUPAC_to_SMILES
@@ -2150,8 +2115,12 @@ def draw_chem3d(draw_this, mono_list, filepath = None):
 
 
 @rescue_glycans
-def GlycoDraw(draw_this, vertical = False, compact = False, show_linkage = True, dim = 50, highlight_motif = None, highlight_termini_list = [],
-              repeat = None, repeat_range = None, draw_method = None, filepath = None, suppress = False, per_residue = []):
+def GlycoDraw(draw_this: str, vertical: bool = False, compact: bool = False, 
+              show_linkage: bool = True, dim: float = 50, highlight_motif: str | None = None,
+              highlight_termini_list: list = [], repeat: bool | int | str | None = None,
+              repeat_range: list[int] | None = None, draw_method: str | None = None,
+              filepath: str | None = None, suppress: bool = False,
+              per_residue: list = []) -> draw.Drawing:
   """Draws a glycan structure based on the provided input.\n
   | Arguments:
   | :-
@@ -2167,8 +2136,7 @@ def GlycoDraw(draw_this, vertical = False, compact = False, show_linkage = True,
   | draw_method (string, optional): Specify 'chem2d' or 'chem3d' to draw chemical structures; default:None (SNFG figure)
   | filepath (string, optional): The path to the output file to save as SVG or PDF when drawing SNFG/chem2d figures or PDB when generating 3D conformers. Default: None.
   | suppress (bool, optional): Whether to suppress the visual display of drawings into the console; default:False
-  | per_residue (list, optional): list of floats (order should be the same as the monosaccharides in glycan string) to quantitatively highlight monosaccharides.\n
-  """
+  | per_residue (list, optional): list of floats (order should be the same as the monosaccharides in glycan string) to quantitatively highlight monosaccharides.\n"""
   if any([k in draw_this for k in [';', '-D-', 'RES', '=']]):
     raise Exception
   if draw_this.startswith('Terminal') and draw_this not in motif_list.motif_name.values.tolist():
@@ -2425,7 +2393,7 @@ def GlycoDraw(draw_this, vertical = False, compact = False, show_linkage = True,
   return d2 if is_jupyter() or suppress or filepath else display_svg_with_matplotlib(d2)
 
 
-def scale_in_range(listy, a, b):
+def scale_in_range(listy: list[float], a: float, b: float) -> list[float]:
   """Normalize list of numbers in range a to b\n
   | Arguments:
   | :-
@@ -2434,16 +2402,16 @@ def scale_in_range(listy, a, b):
   | b (integer/float): max value in normalized range\n
   | Returns:
   | :-
-  | Normalized list of numbers
-  """
+  | Normalized list of numbers"""
   min_val = min(listy)
   max_val = max(listy)
   range_val = max_val - min_val
   return [(b - a) * ((x - min_val) / range_val) + a for x in listy]
 
 
-def annotate_figure(svg_input, scale_range = (25, 80), compact = False, glycan_size = 'medium', filepath = '',
-                    scale_by_DE_res = None, x_thresh = 1, y_thresh = 0.05, x_metric = 'Log2FC'):
+def annotate_figure(svg_input: str, scale_range: tuple[int, int] = (25, 80), compact: bool = False, glycan_size: str = 'medium',
+                   filepath: str = '', scale_by_DE_res: pd.DataFrame | None = None, x_thresh: float = 1, y_thresh: float = 0.05,
+                   x_metric: str = 'Log2FC') -> str | None:
   """Modify matplotlib svg figure to replace text labels with glycan figures\n
   | Arguments:
   | :-
@@ -2458,8 +2426,7 @@ def annotate_figure(svg_input, scale_range = (25, 80), compact = False, glycan_s
   | x_metric (string): x-axis metric; default:'Log2FC'; options are 'Log2FC', 'Effect size'\n
   | Returns:
   | :-
-  | Modified figure svg code
-  """
+  | Modified figure svg code"""
   glycan_size_dict = {
       'small': 'scale(0.1 0.1)  translate(0, -74)',
       'medium': 'scale(0.2 0.2)  translate(0, -55)',
@@ -2537,8 +2504,8 @@ def annotate_figure(svg_input, scale_range = (25, 80), compact = False, glycan_s
     return svg_tmp
 
 
-def plot_glycans_excel(df, folder_filepath, glycan_col_num = 0,
-                       scaling_factor = 0.2, compact = False):
+def plot_glycans_excel(df: pd.DataFrame | str, folder_filepath: str, glycan_col_num: int = 0,
+                       scaling_factor: float = 0.2, compact: bool = False) -> None:
   """plots SNFG images of glycans into new column in df and saves df as Excel file\n
   | Arguments:
   | :-
@@ -2549,8 +2516,7 @@ def plot_glycans_excel(df, folder_filepath, glycan_col_num = 0,
   | compact (bool, optional): Set to True to draw the structures in a compact form. Default: False.\n
   | Returns:
   | :-
-  | Saves the dataframe with glycan images as output.xlsx into folder_filepath
-  """
+  | Saves the dataframe with glycan images as output.xlsx into folder_filepath"""
   try:
     from cairosvg import svg2png
   except:

--- a/glycowork/motif/graph.py
+++ b/glycowork/motif/graph.py
@@ -1,5 +1,6 @@
 import re
 from copy import deepcopy
+from typing import Dict, List, Tuple, Set, Union, Optional, Callable
 from glycowork.glycan_data.loader import unwrap, modification_map
 from glycowork.motif.processing import min_process_glycans, bracket_removal, get_possible_linkages, get_possible_monosaccharides, rescue_glycans, choose_correct_isoform
 import numpy as np
@@ -10,15 +11,10 @@ from functools import lru_cache
 
 
 @lru_cache(maxsize = 1024)
-def evaluate_adjacency(glycan_part: str, adjustment: int) -> bool:
-  """checks whether two glycoletters are adjacent in the graph-to-be-constructed\n
-  | Arguments:
-  | :-
-  | glycan_part (string): residual part of a glycan from within glycan_to_graph
-  | adjustment (int): number of characters to allow for extra length (consequence of tokenizing glycoletters)\n
-  | Returns:
-  | :-
-  | Returns True if adjacent and False if not"""
+def evaluate_adjacency(glycan_part: str, # Residual part of a glycan from within glycan_to_graph
+                      adjustment: int    # Number of characters to allow for extra length (consequence of tokenizing glycoletters)
+                     ) -> bool: # True if adjacent, False if not
+  "Checks whether two glycoletters are adjacent in the graph-to-be-constructed"
   last_char = glycan_part[-1]
   len_glycan_part = len(glycan_part)
   # Check whether (i) glycoletters are adjacent in the main chain or (ii) whether glycoletters are connected but separated by a branch delimiter
@@ -27,15 +23,9 @@ def evaluate_adjacency(glycan_part: str, adjustment: int) -> bool:
 
 
 @lru_cache(maxsize = 128)
-def glycan_to_graph(glycan: str) -> tuple[dict[int, str], np.ndarray]:
-  """the monumental function for converting glycans into graphs\n
-  | Arguments:
-  | :-
-  | glycan (string): IUPAC-condensed glycan sequence\n
-  | Returns:
-  | :-
-  | (1) a dictionary of node : monosaccharide/linkage
-  | (2) an adjacency matrix of size glycoletter X glycoletter"""
+def glycan_to_graph(glycan: str  # IUPAC-condensed glycan sequence
+                   ) -> Tuple[Dict[int, str], np.ndarray]: # (Dictionary of node:monosaccharide/linkage, Adjacency matrix)
+  "Convert glycans into graphs"
   # Get glycoletters
   glycan_proc = tuple(min_process_glycans([glycan])[0])
   n = len(glycan_proc)
@@ -67,18 +57,12 @@ def glycan_to_graph(glycan: str) -> tuple[dict[int, str], np.ndarray]:
   return mask_dic, adj_matrix
 
 
-def glycan_to_nxGraph_int(glycan: str, libr: dict[str, int] | None = None, termini: str = 'ignore', 
-                         termini_list: list[str] | None = None) -> nx.Graph:
-  """converts glycans into networkx graphs\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | libr (dict): dictionary of form glycoletter:index
-  | termini (string): whether to encode terminal/internal position of monosaccharides, 'ignore' for skipping, 'calc' for automatic annotation, or 'provided' if this information is provided in termini_list; default:'ignore'
-  | termini_list (list): list of monosaccharide/linkage positions (from 'terminal', 'internal', and 'flexible')\n
-  | Returns:
-  | :-
-  | Returns networkx graph object of glycan"""
+def glycan_to_nxGraph_int(glycan: str, # Glycan in IUPAC-condensed format
+                         libr: Optional[Dict[str, int]] = None, # Dictionary of form glycoletter:index
+                         termini: str = 'ignore', # How to encode terminal/internal position; options: ignore, calc, provided
+                         termini_list: Optional[List[str]] = None # List of positions from terminal/internal/flexible
+                        ) -> nx.Graph: # NetworkX graph object of glycan
+  "Convert glycans into networkx graphs"
   # This allows to make glycan graphs of motifs ending in a linkage
   cache = glycan.endswith(')')
   if cache:
@@ -113,18 +97,12 @@ def glycan_to_nxGraph_int(glycan: str, libr: dict[str, int] | None = None, termi
 
 
 @rescue_glycans
-def glycan_to_nxGraph(glycan: str, libr: dict[str, int] | None = None, termini: str = 'ignore', 
-                     termini_list: list[str] | None = None) -> nx.Graph:
-  """wrapper for converting glycans into networkx graphs; also works with floating substituents\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | libr (dict): dictionary of form glycoletter:index
-  | termini (string): whether to encode terminal/internal position of monosaccharides, 'ignore' for skipping, 'calc' for automatic annotation, or 'provided' if this information is provided in termini_list; default:'ignore'
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')\n
-  | Returns:
-  | :-
-  | Returns networkx graph object of glycan"""
+def glycan_to_nxGraph(glycan: str, # Glycan in IUPAC-condensed format
+                      libr: Optional[Dict[str, int]] = None, # Dictionary of form glycoletter:index
+                      termini: str = 'ignore', # How to encode terminal/internal position; options: ignore, calc, provided
+                      termini_list: Optional[List[str]] = None # List of positions from terminal/internal/flexible
+                     ) -> nx.Graph: # NetworkX graph object of glycan
+  "Wrapper for converting glycans into networkx graphs; also works with floating substituents"
   if any([k in glycan for k in [';', '-D-', 'RES', '=']]):
     raise Exception
   if termini_list:
@@ -143,20 +121,20 @@ def glycan_to_nxGraph(glycan: str, libr: dict[str, int] | None = None, termini: 
   return g1
 
 
-def ensure_graph(glycan: str | nx.Graph, **kwargs) -> nx.Graph:
-  """ensures function compatibility with string glycans and graph glycans\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx graph): glycan in IUPAC-condensed format or as a networkx graph
-  | **kwargs: keyword arguments that are directly passed on to glycan_to_nxGraph\n
-  | Returns:
-  | :-
-  | Returns networkx graph object of glycan"""
+def ensure_graph(glycan: Union[str, nx.Graph], # Glycan in IUPAC-condensed format or as networkx graph
+                **kwargs # Keyword arguments passed to glycan_to_nxGraph
+               ) -> nx.Graph: # NetworkX graph object of glycan
+  "Ensures function compatibility with string glycans and graph glycans"
   return glycan_to_nxGraph(glycan, **kwargs) if isinstance(glycan, str) else glycan
 
 
-def categorical_node_match_wildcard(attr: str | tuple[str, ...], default: str, narrow_wildcard_list: dict[str, list[str]], 
-                                  attr2: str, default2: str) -> bool:
+def categorical_node_match_wildcard(attr: Union[str, Tuple[str, ...]], # Attribute or tuple of attributes to match
+                                  default: str, # Default value if attribute is missing
+                                  narrow_wildcard_list: Dict[str, List[str]], # Dictionary mapping wildcards to possible matches
+                                  attr2: str, # Secondary attribute to match
+                                  default2: str # Default value for secondary attribute
+                                 ) -> Callable[[dict, dict], bool]: # Function that matches node attributes
+  "Match nodes while handling wildcards and flexible positions"
   if isinstance(attr, str):
     def match(data1, data2):
       data1_labels2, data2_labels2 = data1.get(attr2, default2), data2.get(attr2, default2)
@@ -181,21 +159,18 @@ def categorical_node_match_wildcard(attr: str | tuple[str, ...], default: str, n
   return match
 
 
-def ptm_wildcard_for_graph(graph: nx.Graph) -> nx.Graph:
+def ptm_wildcard_for_graph(graph: nx.Graph # Input graph
+                         ) -> nx.Graph: # Modified graph with PTM wildcards
+  "Standardize PTM wildcards in graph"
   for node in graph.nodes:
     graph.nodes[node]['string_labels'] = re.sub(r"(?<=[a-zA-Z])\d+(?=[a-zA-Z])", 'O', graph.nodes[node]['string_labels']).replace('NeuOAc', 'Neu5Ac').replace('NeuOGc', 'Neu5Gc')
   return graph
 
 
-def compare_glycans(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> bool:
-  """returns True if glycans are the same and False if not\n
-  | Arguments:
-  | :-
-  | glycan_a (string or networkx object): glycan in IUPAC-condensed format or as a precomputed networkx object
-  | glycan_b (string or networkx object): glycan in IUPAC-condensed format or as a precomputed networkx object\n
-  | Returns:
-  | :-
-  | Returns True if two glycans are the same and False if not"""
+def compare_glycans(glycan_a: Union[str, nx.Graph], # First glycan to compare
+                   glycan_b: Union[str, nx.Graph] # Second glycan to compare
+                  ) -> bool: # True if glycans are same, False if not
+  "Check if two glycans are identical"
   if glycan_a == glycan_b:
     return True
   if isinstance(glycan_a, str) and isinstance(glycan_b, str):
@@ -224,15 +199,10 @@ def compare_glycans(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> bool:
       return False
 
 
-def expand_termini_list(motif: str | nx.Graph, termini_list: list[str]) -> list[str]:
-  """Helper function to convert monosaccharide-only termini list into full termini list\n
-  | Arguments:
-  | :-
-  | motif (string or networkx): glycan motif in IUPAC-condensed format or as graph in NetworkX format
-  | termini_list (list): list of monosaccharide/linkage positions (from 'terminal', 'internal', and 'flexible')\n
-  | Returns:
-  | :-
-  | Returns expanded termini_list"""
+def expand_termini_list(motif: Union[str, nx.Graph], # Glycan motif sequence or graph
+                       termini_list: List[str] # List of monosaccharide/linkage positions from terminal/internal/flexible
+                      ) -> List[str]: # Expanded termini list including linkages
+  "Convert monosaccharide-only termini list into full termini list"
   if len(termini_list[0]) < 2:
     mapping = {'t': 'terminal', 'i': 'internal', 'f': 'flexible'}
     termini_list = [mapping[t] for t in termini_list]
@@ -243,7 +213,9 @@ def expand_termini_list(motif: str | nx.Graph, termini_list: list[str]) -> list[
   return t_list
 
 
-def handle_negation(original_func):
+def handle_negation(original_func: Callable # Function to wrap
+                  ) -> Callable: # Wrapped function handling negation
+  "Decorator for handling negation patterns in glycan matching functions"
   def wrapper(glycan, motif, *args, **kwargs):
     if isinstance(motif, str) and '!' in motif:
       return subgraph_isomorphism_with_negation(glycan, motif, *args, **kwargs)
@@ -255,19 +227,13 @@ def handle_negation(original_func):
 
 
 @handle_negation
-def subgraph_isomorphism(glycan: str | nx.Graph, motif: str | nx.Graph, 
-                        termini_list: list = [], count: bool = False, return_matches: bool = False) -> bool | int | tuple[int, list[list[int]]]:
-  """returns True if motif is in glycan and False if not\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format or as graph in NetworkX format
-  | motif (string or networkx): glycan motif in IUPAC-condensed format or as graph in NetworkX format
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')
-  | count (bool): whether to return the number or absence/presence of motifs; default:False
-  | return_matches (bool): whether the matched subgraphs in input glycan should be returned as node lists as an additional output; default:False\n
-  | Returns:
-  | :-
-  | Returns True if motif is in glycan and False if not"""
+def subgraph_isomorphism(glycan: Union[str, nx.Graph], # Glycan sequence or graph
+                        motif: Union[str, nx.Graph], # Glycan motif sequence or graph
+                        termini_list: List = [], # List of monosaccharide positions from terminal/internal/flexible
+                        count: bool = False, # Whether to return count instead of presence/absence
+                        return_matches: bool = False # Whether to return matched subgraphs as node lists
+                       ) -> Union[bool, int, Tuple[int, List[List[int]]]]: # Boolean presence, count, or (count, matches)
+  "Check if motif exists as subgraph in glycan"
   if isinstance(glycan, str) and isinstance(motif, str):
     if motif.count('(') > glycan.count('('):
       return (0, []) if return_matches else 0 if count else False
@@ -331,19 +297,13 @@ def subgraph_isomorphism(glycan: str | nx.Graph, motif: str | nx.Graph,
   return False if not return_matches else (0, [])
 
 
-def subgraph_isomorphism_with_negation(glycan: str | nx.Graph, motif: str | nx.Graph, 
-                                     termini_list: list = [], count: bool = False, return_matches: bool = False) -> bool | int | tuple[int, list[list[int]]]:
-  """returns True if motif is in glycan and False if not\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format or as graph in NetworkX format
-  | motif (string or networkx): glycan motif in IUPAC-condensed format or as graph in NetworkX format
-  | termini_list (list): list of monosaccharide positions (from 'terminal', 'internal', and 'flexible')
-  | count (bool): whether to return the number or absence/presence of motifs; default:False
-  | return_matches (bool): whether the matched subgraphs in input glycan should be returned as node lists as an additional output; default:False\n
-  | Returns:
-  | :-
-  | Returns True if motif is in glycan and False if not"""
+def subgraph_isomorphism_with_negation(glycan: Union[str, nx.Graph], # Glycan sequence or graph
+                                     motif: Union[str, nx.Graph], # Glycan motif sequence or graph
+                                     termini_list: List = [], # List of monosaccharide positions
+                                     count: bool = False, # Whether to return count instead of presence/absence
+                                     return_matches: bool = False # Whether to return matched subgraphs as node lists
+                                    ) -> Union[bool, int, Tuple[int, List[List[int]]]]: # Boolean presence, count, or (count, matches)
+  "Check if motif exists as subgraph in glycan, handling negation patterns"
   if isinstance(motif, str):
     temp = motif[motif.index('!'):]
     motif_stub = (motif[:motif.index('!')] + temp[temp.index(')')+1:]).replace('[]', '')
@@ -371,16 +331,11 @@ def subgraph_isomorphism_with_negation(glycan: str | nx.Graph, motif: str | nx.G
       return res
 
 
-def generate_graph_features(glycan: str | nx.Graph, glycan_graph: bool = True, label: str = 'network') -> pd.DataFrame:
-    """compute graph features of glycan\n
-    | Arguments:
-    | :-
-    | glycan (string or networkx object): glycan in IUPAC-condensed format (or glycan network if glycan_graph=False)
-    | glycan_graph (bool): True expects a glycan, False expects a network (from construct_network); default:True
-    | label (string): Label to place in output dataframe if glycan_graph=False; default:'network'\n
-    | Returns:
-    | :-
-    | Returns a pandas dataframe with different graph features as columns and glycan as row"""
+def generate_graph_features(glycan: Union[str, nx.Graph], # Glycan sequence or network graph
+                          glycan_graph: bool = True, # True if input is glycan, False if network
+                          label: str = 'network' # Label for output dataframe if glycan_graph=False
+                         ) -> pd.DataFrame: # Dataframe of graph features
+    "Compute graph features of glycan or network"
     g = ensure_graph(glycan) if glycan_graph else glycan
     glycan = label if not glycan_graph else glycan
     nbr_node_types = len(set(nx.get_node_attributes(g, "labels") if glycan_graph else g.nodes()))
@@ -427,38 +382,23 @@ def generate_graph_features(glycan: str | nx.Graph, glycan_graph: bool = True, l
     return pd.DataFrame(features, index = [glycan])
 
 
-def neighbor_is_branchpoint(graph: nx.Graph, node: int) -> bool:
-  """checks whether node is connected to downstream node with more than two branches\n
-  | Arguments:
-  | :-
-  | graph (networkx object): glycan graph
-  | node (int): node index\n
-  | Returns:
-  | :-
-  | Returns True if node is connected to downstream multi-branch node and False if not"""
+def neighbor_is_branchpoint(graph: nx.Graph, # Glycan graph
+                          node: int # Node index to check
+                         ) -> bool: # True if connected to downstream multi-branch node
+  "Check if node is connected to downstream node with >2 branches"
   edges = graph.edges(node)
   edges = unwrap([e for e in edges if sum(e) > 2*node])
   edges = [graph.degree[e] for e in set(edges) if e != node]
   return max(edges, default = 0) > 3
 
 
-def graph_to_string_int(graph: nx.Graph) -> str:
-  """converts glycan graph back to IUPAC-condensed format\n
-  | Arguments:
-  | :-
-  | graph (networkx object): glycan graph\n
-  | Returns:
-  | :-
-  | Returns glycan in IUPAC-condensed format (string)"""
-  def assign_depth(G: nx.DiGraph, idx: int):
-    """Assigns depth to each node in the graph recursively. Stored as the node attribute "depth".\n
-    | Arguments:
-    | :-
-    | G (networkx object): glycan graph
-    | idx (int): node index\n
-    | Returns:
-    | :-
-    | Returns depth of the node"""
+def graph_to_string_int(graph: nx.Graph # Glycan graph
+                      ) -> str: # IUPAC-condensed glycan string
+  "Convert glycan graph back to IUPAC-condensed format"
+  def assign_depth(G: nx.DiGraph, # Directed glycan graph
+                idx: int # Node index
+               ) -> float: # Depth of the node
+    "Assign depth to each node in the graph recursively"
     min_depth = float("inf")
     children = list(G.neighbors(idx))
     if len(children) == 0:  # if it's a leaf node, the depth is zero
@@ -469,15 +409,10 @@ def graph_to_string_int(graph: nx.Graph) -> str:
     G.nodes[idx]["depth"] = min_depth
     return min_depth
 
-  def dfs_to_string(G: nx.DiGraph, idx: int):
-    """Converts the DFT tree of a glycan graph to IUPAC-condensed format recursively.\n
-    | Arguments:
-    | :-
-    | G (networkx object): DFS tree of a glycan graph
-    | idx (int): node index\n
-    | Returns:
-    | :-
-    | Returns glycan in IUPAC-condensed format (string)"""
+  def dfs_to_string(G: nx.DiGraph, # DFS tree of glycan graph
+                 idx: int # Node index
+                ) -> str: # IUPAC-condensed glycan string
+    "Convert the DFS tree of a glycan graph to IUPAC-condensed format recursively"
     output = graph.nodes[idx]["string_labels"]
     # put braces around the string describing linkages
     if (output[0] in "?abn" or output[0].isdigit()) and (output[-1] == "?" or output[-1].isdigit()):
@@ -505,18 +440,9 @@ def graph_to_string_int(graph: nx.Graph) -> str:
   return dfs_to_string(dfs, root_idx)
 
 
-def graph_to_string(graph: nx.Graph) -> str:
-  """converts glycan graph back to IUPAC-condensed format\n
-
-  Assumptions:
-  1. The root node is the one with the highest index.
-
-  | Arguments:
-  | :-
-  | graph (networkx object): glycan graph\n
-  | Returns:
-  | :-
-  | Returns glycan in IUPAC-condensed format (string)"""
+def graph_to_string(graph: nx.Graph # Glycan graph (assumes root node is the one with the highest index)
+                  ) -> str: # IUPAC-condensed glycan string
+  "Convert glycan graph back to IUPAC-condensed format, handling disconnected components"
   if nx.number_connected_components(graph) > 1:
     parts = [graph.subgraph(sorted(c)) for c in nx.connected_components(graph)]
     len_org = len(parts[-1])
@@ -532,14 +458,9 @@ def graph_to_string(graph: nx.Graph) -> str:
     return graph_to_string_int(graph)
 
 
-def try_string_conversion(graph: nx.Graph) -> str | None:
-  """check whether glycan graph describes a valid glycan\n
-  | Arguments:
-  | :-
-  | graph (networkx object): glycan graph, works with branched glycans\n
-  | Returns:
-  | :-
-  | Returns glycan in IUPAC-condensed format (string) if glycan is valid, otherwise returns None"""
+def try_string_conversion(graph: nx.Graph # Glycan graph to validate
+                        ) -> Optional[str]: # IUPAC string if valid, None if invalid
+  "Check whether glycan graph describes a valid glycan"
   try:
     temp = graph_to_string(graph)
     temp = glycan_to_nxGraph(temp)
@@ -548,15 +469,10 @@ def try_string_conversion(graph: nx.Graph) -> str | None:
     return None
 
 
-def largest_subgraph(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> str:
-  """find the largest common subgraph of two glycans\n
-  | Arguments:
-  | :-
-  | glycan_a (string or networkx): glycan in IUPAC-condensed format or as networkx graph
-  | glycan_b (string or networkx): glycan in IUPAC-condensed format or as networkx graph\n
-  | Returns:
-  | :-
-  | Returns the largest common subgraph as a string in IUPAC-condensed; returns empty string if there is no common subgraph"""
+def largest_subgraph(glycan_a: Union[str, nx.Graph], # First glycan
+                    glycan_b: Union[str, nx.Graph] # Second glycan
+                   ) -> str: # Largest common subgraph in IUPAC format
+  "Find the largest common subgraph of two glycans"
   graph_a = ensure_graph(glycan_a)
   graph_b = ensure_graph(glycan_b)
   ismags = nx.isomorphism.ISMAGS(graph_a, graph_b,
@@ -575,17 +491,12 @@ def largest_subgraph(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> str:
     return ""
 
 
-def get_possible_topologies(glycan: str | nx.Graph, exhaustive: bool = False, 
-                          allowed_disaccharides: set[str] | None = None, modification_map: dict[str, set[str]] = modification_map) -> list[nx.Graph]:
-  """creates possible glycans given a floating substituent; only works with max one floating substituent\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format or as networkx graph
-  | exhaustive (bool): whether to also allow additions at internal positions; default:False
-  | allowed_disaccharides (set): disaccharides that are permitted when creating possible glycans; default:not used\n
-  | Returns:
-  | :-
-  | Returns list of NetworkX-like glycan graphs of possible topologies"""
+def get_possible_topologies(glycan: Union[str, nx.Graph], # Glycan with floating substituent
+                          exhaustive: bool = False, # Whether to allow additions at internal positions
+                          allowed_disaccharides: Optional[Set[str]] = None, # Permitted disaccharides when creating possible glycans
+                          modification_map: Dict[str, Set[str]] = modification_map # Maps modifications to valid attachments
+                         ) -> List[nx.Graph]: # List of possible topology graphs
+  "Create possible glycan graphs given a floating substituent"
   if isinstance(glycan, str):
     if '{' not in glycan:
       print("This glycan already has a defined topology; please don't use this function.")
@@ -628,31 +539,20 @@ def get_possible_topologies(glycan: str | nx.Graph, exhaustive: bool = False,
   return topologies
 
 
-def possible_topology_check(glycan: str | nx.Graph, glycans: list[str | nx.Graph], 
-                          exhaustive: bool = False, **kwargs) -> list[str | nx.Graph]:
-  """checks whether glycan with floating substituent could match glycans from a list; only works with max one floating substituent\n
-  | Arguments:
-  | :-
-  | glycan (string or networkx): glycan in IUPAC-condensed format (or as networkx graph) that has to contain a floating substituent
-  | glycans (list): list of glycans in IUPAC-condensed format (or networkx graphs; should not contain floating substituents)
-  | exhaustive (bool): whether to also allow additions at internal positions; default:False
-  | **kwargs: keyword arguments that are directly passed on to compare_glycans\n
-  | Returns:
-  | :-
-  | Returns list of glycans that could match input glycan"""
+def possible_topology_check(glycan: Union[str, nx.Graph], # Glycan with floating substituent
+                          glycans: List[Union[str, nx.Graph]], # List of glycans to check against
+                          exhaustive: bool = False, # Whether to allow additions at internal positions
+                          **kwargs # Arguments passed to compare_glycans
+                         ) -> List[Union[str, nx.Graph]]: # List of matching glycans
+  "Check whether glycan with floating substituent could match glycans from a list"
   topologies = get_possible_topologies(glycan, exhaustive = exhaustive)
   ggraphs = map(ensure_graph, glycans)
   return [g for g, ggraph in zip(glycans, ggraphs) if any(compare_glycans(t, ggraph, **kwargs) for t in topologies)]
 
 
-def deduplicate_glycans(glycans: list[str] | set[str]) -> list[str]:
-  """removes duplicate glycans from a list/set, even if they have different strings\n
-  | Arguments:
-  | :-
-  | glycans (list or set): glycans in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns deduplicated list of glycans"""
+def deduplicate_glycans(glycans: Union[List[str], Set[str]] # List/set of glycans to deduplicate
+                      ) -> List[str]: # Deduplicated list of glycans
+  "Remove duplicate glycans from a list/set, even if they have different strings"
   if not glycans:
     return []
   glycans = list(glycans) if isinstance(glycans, set) else list(set(glycans))

--- a/glycowork/motif/graph.py
+++ b/glycowork/motif/graph.py
@@ -1,7 +1,7 @@
 import re
 from copy import deepcopy
 from glycowork.glycan_data.loader import unwrap, modification_map
-from glycowork.motif.processing import min_process_glycans, canonicalize_iupac, bracket_removal, get_possible_linkages, get_possible_monosaccharides, rescue_glycans, choose_correct_isoform
+from glycowork.motif.processing import min_process_glycans, bracket_removal, get_possible_linkages, get_possible_monosaccharides, rescue_glycans, choose_correct_isoform
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -598,7 +598,7 @@ def get_possible_topologies(glycan, exhaustive = False, allowed_disaccharides = 
     dangling_carbon = ggraph.nodes[dangling_linkage]['string_labels'][-1]
     floating_monosaccharide = dangling_linkage - 1
   topologies = []
-  candidate_nodes = [k for k in list(main_part.nodes())[::2] 
+  candidate_nodes = [k for k in list(main_part.nodes())[::2]
                      if exhaustive or (main_part.degree[k] == 1 and k != max(main_part.nodes()))]
   for k in candidate_nodes:
     neighbor_carbons = [ggraph.nodes[n]['string_labels'][-1] for n in ggraph.neighbors(k) if n < k]

--- a/glycowork/motif/graph.py
+++ b/glycowork/motif/graph.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 
 
 @lru_cache(maxsize = 1024)
-def evaluate_adjacency(glycan_part, adjustment):
+def evaluate_adjacency(glycan_part: str, adjustment: int) -> bool:
   """checks whether two glycoletters are adjacent in the graph-to-be-constructed\n
   | Arguments:
   | :-
@@ -27,7 +27,7 @@ def evaluate_adjacency(glycan_part, adjustment):
 
 
 @lru_cache(maxsize = 128)
-def glycan_to_graph(glycan):
+def glycan_to_graph(glycan: str) -> tuple[dict[int, str], np.ndarray]:
   """the monumental function for converting glycans into graphs\n
   | Arguments:
   | :-
@@ -67,8 +67,8 @@ def glycan_to_graph(glycan):
   return mask_dic, adj_matrix
 
 
-def glycan_to_nxGraph_int(glycan, libr = None,
-                          termini = 'ignore', termini_list = None):
+def glycan_to_nxGraph_int(glycan: str, libr: dict[str, int] | None = None, termini: str = 'ignore', 
+                         termini_list: list[str] | None = None) -> nx.Graph:
   """converts glycans into networkx graphs\n
   | Arguments:
   | :-
@@ -113,8 +113,8 @@ def glycan_to_nxGraph_int(glycan, libr = None,
 
 
 @rescue_glycans
-def glycan_to_nxGraph(glycan, libr = None,
-                      termini = 'ignore', termini_list = None):
+def glycan_to_nxGraph(glycan: str, libr: dict[str, int] | None = None, termini: str = 'ignore', 
+                     termini_list: list[str] | None = None) -> nx.Graph:
   """wrapper for converting glycans into networkx graphs; also works with floating substituents\n
   | Arguments:
   | :-
@@ -143,7 +143,7 @@ def glycan_to_nxGraph(glycan, libr = None,
   return g1
 
 
-def ensure_graph(glycan, **kwargs):
+def ensure_graph(glycan: str | nx.Graph, **kwargs) -> nx.Graph:
   """ensures function compatibility with string glycans and graph glycans\n
   | Arguments:
   | :-
@@ -155,7 +155,8 @@ def ensure_graph(glycan, **kwargs):
   return glycan_to_nxGraph(glycan, **kwargs) if isinstance(glycan, str) else glycan
 
 
-def categorical_node_match_wildcard(attr, default, narrow_wildcard_list, attr2, default2):
+def categorical_node_match_wildcard(attr: str | tuple[str, ...], default: str, narrow_wildcard_list: dict[str, list[str]], 
+                                  attr2: str, default2: str) -> bool:
   if isinstance(attr, str):
     def match(data1, data2):
       data1_labels2, data2_labels2 = data1.get(attr2, default2), data2.get(attr2, default2)
@@ -180,13 +181,13 @@ def categorical_node_match_wildcard(attr, default, narrow_wildcard_list, attr2, 
   return match
 
 
-def ptm_wildcard_for_graph(graph):
+def ptm_wildcard_for_graph(graph: nx.Graph) -> nx.Graph:
   for node in graph.nodes:
     graph.nodes[node]['string_labels'] = re.sub(r"(?<=[a-zA-Z])\d+(?=[a-zA-Z])", 'O', graph.nodes[node]['string_labels']).replace('NeuOAc', 'Neu5Ac').replace('NeuOGc', 'Neu5Gc')
   return graph
 
 
-def compare_glycans(glycan_a, glycan_b):
+def compare_glycans(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> bool:
   """returns True if glycans are the same and False if not\n
   | Arguments:
   | :-
@@ -223,7 +224,7 @@ def compare_glycans(glycan_a, glycan_b):
       return False
 
 
-def expand_termini_list(motif, termini_list):
+def expand_termini_list(motif: str | nx.Graph, termini_list: list[str]) -> list[str]:
   """Helper function to convert monosaccharide-only termini list into full termini list\n
   | Arguments:
   | :-
@@ -254,7 +255,8 @@ def handle_negation(original_func):
 
 
 @handle_negation
-def subgraph_isomorphism(glycan, motif, termini_list = [], count = False, return_matches = False):
+def subgraph_isomorphism(glycan: str | nx.Graph, motif: str | nx.Graph, 
+                        termini_list: list = [], count: bool = False, return_matches: bool = False) -> bool | int | tuple[int, list[list[int]]]:
   """returns True if motif is in glycan and False if not\n
   | Arguments:
   | :-
@@ -329,7 +331,8 @@ def subgraph_isomorphism(glycan, motif, termini_list = [], count = False, return
   return False if not return_matches else (0, [])
 
 
-def subgraph_isomorphism_with_negation(glycan, motif, termini_list = [], count = False, return_matches = False):
+def subgraph_isomorphism_with_negation(glycan: str | nx.Graph, motif: str | nx.Graph, 
+                                     termini_list: list = [], count: bool = False, return_matches: bool = False) -> bool | int | tuple[int, list[list[int]]]:
   """returns True if motif is in glycan and False if not\n
   | Arguments:
   | :-
@@ -368,7 +371,7 @@ def subgraph_isomorphism_with_negation(glycan, motif, termini_list = [], count =
       return res
 
 
-def generate_graph_features(glycan, glycan_graph = True, label = 'network'):
+def generate_graph_features(glycan: str | nx.Graph, glycan_graph: bool = True, label: str = 'network') -> pd.DataFrame:
     """compute graph features of glycan\n
     | Arguments:
     | :-
@@ -424,7 +427,7 @@ def generate_graph_features(glycan, glycan_graph = True, label = 'network'):
     return pd.DataFrame(features, index = [glycan])
 
 
-def neighbor_is_branchpoint(graph, node):
+def neighbor_is_branchpoint(graph: nx.Graph, node: int) -> bool:
   """checks whether node is connected to downstream node with more than two branches\n
   | Arguments:
   | :-
@@ -439,7 +442,7 @@ def neighbor_is_branchpoint(graph, node):
   return max(edges, default = 0) > 3
 
 
-def graph_to_string_int(graph):
+def graph_to_string_int(graph: nx.Graph) -> str:
   """converts glycan graph back to IUPAC-condensed format\n
   | Arguments:
   | :-
@@ -502,7 +505,7 @@ def graph_to_string_int(graph):
   return dfs_to_string(dfs, root_idx)
 
 
-def graph_to_string(graph):
+def graph_to_string(graph: nx.Graph) -> str:
   """converts glycan graph back to IUPAC-condensed format\n
 
   Assumptions:
@@ -529,7 +532,7 @@ def graph_to_string(graph):
     return graph_to_string_int(graph)
 
 
-def try_string_conversion(graph):
+def try_string_conversion(graph: nx.Graph) -> str | None:
   """check whether glycan graph describes a valid glycan\n
   | Arguments:
   | :-
@@ -545,7 +548,7 @@ def try_string_conversion(graph):
     return None
 
 
-def largest_subgraph(glycan_a, glycan_b):
+def largest_subgraph(glycan_a: str | nx.Graph, glycan_b: str | nx.Graph) -> str:
   """find the largest common subgraph of two glycans\n
   | Arguments:
   | :-
@@ -572,8 +575,8 @@ def largest_subgraph(glycan_a, glycan_b):
     return ""
 
 
-def get_possible_topologies(glycan, exhaustive = False, allowed_disaccharides = None,
-                            modification_map = modification_map):
+def get_possible_topologies(glycan: str | nx.Graph, exhaustive: bool = False, 
+                          allowed_disaccharides: set[str] | None = None, modification_map: dict[str, set[str]] = modification_map) -> list[nx.Graph]:
   """creates possible glycans given a floating substituent; only works with max one floating substituent\n
   | Arguments:
   | :-
@@ -625,7 +628,8 @@ def get_possible_topologies(glycan, exhaustive = False, allowed_disaccharides = 
   return topologies
 
 
-def possible_topology_check(glycan, glycans, exhaustive = False, **kwargs):
+def possible_topology_check(glycan: str | nx.Graph, glycans: list[str | nx.Graph], 
+                          exhaustive: bool = False, **kwargs) -> list[str | nx.Graph]:
   """checks whether glycan with floating substituent could match glycans from a list; only works with max one floating substituent\n
   | Arguments:
   | :-
@@ -641,7 +645,7 @@ def possible_topology_check(glycan, glycans, exhaustive = False, **kwargs):
   return [g for g, ggraph in zip(glycans, ggraphs) if any(compare_glycans(t, ggraph, **kwargs) for t in topologies)]
 
 
-def deduplicate_glycans(glycans):
+def deduplicate_glycans(glycans: list[str] | set[str]) -> list[str]:
   """removes duplicate glycans from a list/set, even if they have different strings\n
   | Arguments:
   | :-

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -32,34 +32,32 @@ monosaccharide_mapping = {
     }
 
 
-def min_process_glycans(glycan_list):
+def min_process_glycans(glycan_list: list[str]) -> list[list[str]]:
   """converts list of glycans into a nested lists of glycoletters\n
   | Arguments:
   | :-
   | glycan_list (list): list of glycans in IUPAC-condensed format as strings\n
   | Returns:
   | :-
-  | Returns list of glycoletter lists
-  """
+  | Returns list of glycoletter lists"""
   return [[x for x in multireplace(k, {'[': '', ']': '', '{': '', '}': '', ')': '('}).split('(') if x] for k in glycan_list]
 
 
-def get_lib(glycan_list):
+def get_lib(glycan_list: list[str]) -> dict[str, int]:
   """returns dictionary of form glycoletter:index\n
   | Arguments:
   | :-
   | glycan_list (list): list of IUPAC-condensed glycan sequences as strings\n
   | Returns:
   | :-
-  | Returns dictionary of form glycoletter:index
-  """
+  | Returns dictionary of form glycoletter:index"""
   # Convert to glycoletters & flatten & get unique vocab
   lib = sorted(set(unwrap(min_process_glycans(set(glycan_list)))))
   # Convert to dict
   return {k: i for i, k in enumerate(lib)}
 
 
-def expand_lib(libr, glycan_list):
+def expand_lib(libr: dict[str, int], glycan_list: list[str]) -> dict[str, int]:
   """updates libr with newly introduced glycoletters\n
   | Arguments:
   | :-
@@ -67,8 +65,7 @@ def expand_lib(libr, glycan_list):
   | glycan_list (list): list of IUPAC-condensed glycan sequences as strings\n
   | Returns:
   | :-
-  | Returns new lib
-  """
+  | Returns new lib"""
   new_libr = get_lib(glycan_list)
   offset = len(libr)
   for k, v in new_libr.items():
@@ -77,7 +74,7 @@ def expand_lib(libr, glycan_list):
   return libr
 
 
-def in_lib(glycan, libr):
+def in_lib(glycan: str, libr: dict[str, int]) -> bool:
   """checks whether all glycoletters of glycan are in libr\n
   | Arguments:
   | :-
@@ -85,13 +82,12 @@ def in_lib(glycan, libr):
   | libr (dict): dictionary of form glycoletter:index\n
   | Returns:
   | :-
-  | Returns True if all glycoletters are in libr and False if not
-  """
+  | Returns True if all glycoletters are in libr and False if not"""
   glycan = min_process_glycans([glycan])[0]
   return set(glycan).issubset(libr.keys())
 
 
-def get_possible_linkages(wildcard, linkage_list = linkages):
+def get_possible_linkages(wildcard: str, linkage_list: list[str] = linkages) -> list[str]:
   """Retrieves all linkages that match a given wildcard pattern from a list of linkages\n
   | Arguments:
   | :-
@@ -99,37 +95,34 @@ def get_possible_linkages(wildcard, linkage_list = linkages):
   | linkage_list (list): List of linkages as strings to search within; default:linkages\n
   | Returns:
   | :-
-  | Returns a list of linkages that match the wildcard pattern.
-  """
+  | Returns a list of linkages that match the wildcard pattern."""
   pattern = wildcard.replace("?", r"[a-zA-Z0-9\?]")
   return [linkage for linkage in linkage_list if re.fullmatch(pattern, linkage)]
   #return possible_linkages if libr is None else list(possible_linkages & libr.keys())
 
 
-def get_possible_monosaccharides(wildcard):
+def get_possible_monosaccharides(wildcard: str) -> set[str]:
   """Retrieves all matching common monosaccharides of a type, given the type\n
   | Arguments:
   | :-
   | wildcard (string): Monosaccharide type, from "HexNAc", "HexNAcOS", "Hex", "HexOS", "dHex", "Sia", "HexA", "Pen"\n
   | Returns:
   | :-
-  | Returns a list of specified monosaccharides of that type
-  """
+  | Returns a list of specified monosaccharides of that type"""
   wildcard_dict = {'Hex': Hex, 'HexNAc': HexNAc, 'dHex': dHex, 'Sia': Sia, 'HexA': HexA, 'Pen': Pen,
                    'HexOS': HexOS, 'HexNAcOS': HexNAcOS,
                    'Monosaccharide': set().union(*[Hex, HexOS, HexNAc, HexNAcOS, dHex, Sia, HexA, Pen])}
   return wildcard_dict.get(wildcard, [])
 
 
-def de_wildcard_glycoletter(glycoletter):
+def de_wildcard_glycoletter(glycoletter: str) -> str:
   """Retrieves a random specified instance of a general type (e.g., "Gal" for "Hex")\n
   | Arguments:
   | :-
   | glycoletter (string): Monosaccharide or linkage\n
   | Returns:
   | :-
-  | Returns a random specified glycoletter of that type
-  """
+  | Returns a random specified glycoletter of that type"""
   if '?' in glycoletter:
     return choice(get_possible_linkages(glycoletter))
   elif monos := get_possible_monosaccharides(glycoletter):
@@ -138,30 +131,28 @@ def de_wildcard_glycoletter(glycoletter):
     return glycoletter
 
 
-def bracket_removal(glycan_part):
+def bracket_removal(glycan_part: str) -> str:
   """iteratively removes (nested) branches between start and end of glycan_part\n
   | Arguments:
   | :-
   | glycan_part (string): residual part of a glycan from within glycan_to_graph\n
   | Returns:
   | :-
-  | Returns glycan_part without interfering branches
-  """
+  | Returns glycan_part without interfering branches"""
   regex = re.compile(r'\[[^\[\]]+\]')
   while regex.search(glycan_part):
     glycan_part = regex.sub('', glycan_part)
   return glycan_part
 
 
-def find_isomorphs(glycan):
+def find_isomorphs(glycan: str) -> list[str]:
   """returns a set of isomorphic glycans by swapping branches etc.\n
   | Arguments:
   | :-
   | glycan (string): glycan in IUPAC-condensed format\n
   | Returns:
   | :-
-  | Returns list of unique glycan notations (strings) for a glycan in IUPAC-condensed
-  """
+  | Returns list of unique glycan notations (strings) for a glycan in IUPAC-condensed"""
   floaty = False
   if '{' in glycan:
     floaty = glycan[:glycan.rindex('}')+1]
@@ -190,7 +181,8 @@ def find_isomorphs(glycan):
   return list(out_list)
 
 
-def presence_to_matrix(df, glycan_col_name = 'glycan', label_col_name = 'Species'):
+def presence_to_matrix(df: pd.DataFrame, glycan_col_name: str = 'glycan', 
+                      label_col_name: str = 'Species') -> pd.DataFrame:
   """converts a dataframe such as df_species to absence/presence matrix\n
   | Arguments:
   | :-
@@ -199,15 +191,13 @@ def presence_to_matrix(df, glycan_col_name = 'glycan', label_col_name = 'Species
   | label_col_name (string): column name under which labels are stored; default:Species\n
   | Returns:
   | :-
-  | Returns pandas dataframe with labels as rows and glycan occurrences as columns
-  """
+  | Returns pandas dataframe with labels as rows and glycan occurrences as columns"""
   # Create a grouped dataframe where we count the occurrences of each glycan in each species group
   grouped_df = df.groupby([label_col_name, glycan_col_name]).size().unstack(fill_value = 0)
-  # Sort the index and columns
   return grouped_df.sort_index().sort_index(axis = 1)
 
 
-def find_matching_brackets_indices(s):
+def find_matching_brackets_indices(s: str) -> list[tuple[int, int]] | None:
   stack = []
   matching_indices = []
   for i, c in enumerate(s):
@@ -225,7 +215,7 @@ def find_matching_brackets_indices(s):
     return matching_indices
 
 
-def choose_correct_isoform(glycans, reverse = False):
+def choose_correct_isoform(glycans: list[str], reverse: bool = False) -> str | list[str]:
   """given a list of glycan branch isomers, this function returns the correct isomer\n
   | Arguments:
   | :-
@@ -233,8 +223,7 @@ def choose_correct_isoform(glycans, reverse = False):
   | reverse (bool): whether to return the correct isomer (False) or everything except the correct isomer (True); default:False\n
   | Returns:
   | :-
-  | Returns the correct isomer as a string (if reverse=False; otherwise it returns a list of strings)
-  """
+  | Returns the correct isomer as a string (if reverse=False; otherwise it returns a list of strings)"""
   glycans = list(set(glycans))
   if '?' in ''.join(glycans) and not reverse:
     min_questions = min(glycan.count('?') for glycan in glycans)
@@ -300,7 +289,7 @@ def choose_correct_isoform(glycans, reverse = False):
   return correct_isoform
 
 
-def enforce_class(glycan, glycan_class, conf = None, extra_thresh = 0.3):
+def enforce_class(glycan: str, glycan_class: str, conf: float | None = None, extra_thresh: float = 0.3) -> bool:
   """given a glycan and glycan class, determines whether glycan is from this class\n
   | Arguments:
   | :-
@@ -310,8 +299,7 @@ def enforce_class(glycan, glycan_class, conf = None, extra_thresh = 0.3):
   | extra_thresh (float): threshold to override class; default:0.3\n
   | Returns:
   | :-
-  | Returns True if glycan is in glycan class and False if not
-  """
+  | Returns True if glycan is in glycan class and False if not"""
   pools = {
     'O': 'GalNAc|GalNAcOS|GalNAc[46]S|Man|Fuc|Gal|GlcNAc|GlcNAcOS|GlcNAc6S',
     'N': 'GlcNAc',
@@ -327,15 +315,14 @@ def enforce_class(glycan, glycan_class, conf = None, extra_thresh = 0.3):
   return conf > extra_thresh if not truth and conf is not None else truth
 
 
-def get_class(glycan):
+def get_class(glycan: str) -> str:
   """given a glycan, determines its class\n
   | Arguments:
   | :-
   | glycan (string): glycan in IUPAC-condensed nomenclature\n
   | Returns:
   | :-
-  | Returns "O", "N", "free", or "lipid" (or empty string if not either)
-  """
+  | Returns "O", "N", "free", or "lipid" (or empty string if not either)"""
   if glycan.endswith('-ol'):
     return 'free'
   if glycan.endswith(('1Cer', 'Ins')):
@@ -347,15 +334,14 @@ def get_class(glycan):
   return ''
 
 
-def canonicalize_composition(comp):
+def canonicalize_composition(comp: str) -> dict[str, int]:
   """converts a composition from any common format into the dictionary that is optimized for glycowork\n
   | Arguments:
   | :-
   | comp (string): composition formatted either in the style of Hex5HexNAc4Fuc1Neu5Ac2 or H5N4F1A2\n
   | Returns:
   | :-
-  | Returns composition as a dictionary of style monosaccharide : count
-  """
+  | Returns composition as a dictionary of style monosaccharide : count"""
   if '_' in comp:
     values = comp.split('_')
     temp = {"Hex": int(values[0]), "HexNAc": int(values[1]), "Neu5Ac": int(values[2]), "dHex": int(values[3])}
@@ -402,15 +388,14 @@ def canonicalize_composition(comp):
   return comp_dict
 
 
-def IUPAC_to_SMILES(glycan_list):
+def IUPAC_to_SMILES(glycan_list: list[str]) -> list[str]:
   """given a list of IUPAC-condensed glycans, uses GlyLES to return a list of corresponding isomeric SMILES\n
   | Arguments:
   | :-
   | glycan_list (list): list of IUPAC-condensed glycans\n
   | Returns:
   | :-
-  | Returns a list of corresponding isomeric SMILES
-  """
+  | Returns a list of corresponding isomeric SMILES"""
   try:
     from glyles import convert
   except ImportError:
@@ -420,15 +405,14 @@ def IUPAC_to_SMILES(glycan_list):
   return [convert(g)[0][1] for g in glycan_list]
 
 
-def linearcode_to_iupac(linearcode):
+def linearcode_to_iupac(linearcode: str) -> str:
   """converts a glycan from LinearCode into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
   | Arguments:
   | :-
   | linearcode (string): glycan sequence in LinearCode format\n
   | Returns:
   | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form
-  """
+  | Returns glycan as a string in a barebones IUPAC-condensed form"""
   replace_dic = {'G': 'Glc', 'ME': 'me', 'M': 'Man', 'A': 'Gal', 'NN': 'Neu5Ac', 'GlcN': 'GlcNAc', 'GN': 'GlcNAc',
                  'GalN': 'GalNAc', 'AN': 'GalNAc', 'F': 'Fuc', 'K': 'Kdn', 'W': 'Kdo', 'L': 'GalA', 'I': 'IdoA', 'PYR': 'Pyr', 'R': 'Araf', 'H': 'Rha',
                  'X': 'Xyl', 'B': 'Rib', 'U': 'GlcA', 'O': 'All', 'E': 'Fruf', '[': '', ']': '', 'me': 'Me', 'PC': 'PCho', 'T': 'Ac'}
@@ -436,15 +420,14 @@ def linearcode_to_iupac(linearcode):
   return glycan
 
 
-def iupac_extended_to_condensed(iupac_extended):
+def iupac_extended_to_condensed(iupac_extended: str) -> str:
   """converts a glycan from IUPAC-extended into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
   | Arguments:
   | :-
   | iupac_extended (string): glycan sequence in IUPAC-extended format\n
   | Returns:
   | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form
-  """
+  | Returns glycan as a string in a barebones IUPAC-condensed form"""
   # Find all occurrences of the pattern and apply the changes
   def replace_pattern(match):
     # Move the α or β after the next opening parenthesis
@@ -459,7 +442,8 @@ def iupac_extended_to_condensed(iupac_extended):
   return adjusted_string[:adjusted_string.rindex('(')]
 
 
-def glycoct_to_iupac_int(glycoct, mono_replace, sub_replace):
+def glycoct_to_iupac_int(glycoct: str, mono_replace: dict[str, str], sub_replace: dict[str, str]) -> tuple[dict[int, str], 
+                                                            dict[int, list[tuple[str, int]]], dict[int, int]]:
   # Dictionaries to hold the mapping of residues and linkages
   residue_dic = {}
   iupac_parts = defaultdict(list)
@@ -515,7 +499,8 @@ def glycoct_to_iupac_int(glycoct, mono_replace, sub_replace):
   return residue_dic, iupac_parts, degrees
 
 
-def glycoct_build_iupac(iupac_parts, residue_dic, degrees):
+def glycoct_build_iupac(iupac_parts: dict[int, list[tuple[str, int]]], 
+                       residue_dic: dict[int, str], degrees: dict[int, int]) -> str:
   start = min(residue_dic.keys())
   iupac = residue_dic[start]
   inverted_residue_dic = {}
@@ -548,15 +533,14 @@ def glycoct_build_iupac(iupac_parts, residue_dic, degrees):
   return iupac.strip('[]')
 
 
-def glycoct_to_iupac(glycoct):
+def glycoct_to_iupac(glycoct: str) -> str:
   """converts a glycan from GlycoCT into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
   | Arguments:
   | :-
   | glycoct (string): glycan sequence in GlycoCT format\n
   | Returns:
   | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form
-  """
+  | Returns glycan as a string in a barebones IUPAC-condensed form"""
   floating_bits = []
   floating_part = ''
   mono_replace = {'dglc': 'Glc', 'dgal': 'Gal', 'dman': 'Man', 'lgal': 'Fuc', 'dgro': 'Neu',
@@ -591,15 +575,14 @@ def glycoct_to_iupac(glycoct):
   return iupac
 
 
-def get_mono(token):
+def get_mono(token: str) -> str:
   """maps WURCS token to monosaccharide with anomeric state; provides anomeric flexibility\n
   | Arguments:
   | :-
   | token (string): token indicating monosaccharide in WURCS format\n
   | Returns:
   | :-
-  | Returns monosaccharide with anomeric state as string
-  """
+  | Returns monosaccharide with anomeric state as string"""
   anomer = token[token.index('_')-1]
   if token in monosaccharide_mapping:
     mono = monosaccharide_mapping[token]
@@ -616,15 +599,14 @@ def get_mono(token):
   return mono
 
 
-def wurcs_to_iupac(wurcs):
+def wurcs_to_iupac(wurcs: str) -> str:
   """converts a glycan from WURCS into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
   | Arguments:
   | :-
   | wurcs (string): glycan sequence in WURCS format\n
   | Returns:
   | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form
-  """
+  | Returns glycan as a string in a barebones IUPAC-condensed form"""
   wurcs = wurcs[wurcs.index('/')+1:]
   pattern = r'\b([a-z])\d(?:\|\1\d)+\}?|\b[a-z](\d)(?:\|[a-z]\2)+\}?'
   additional_pattern = r'\b([a-z])\?(?:\|\w\?)+\}?'
@@ -708,15 +690,14 @@ def wurcs_to_iupac(wurcs):
   return iupac
 
 
-def oxford_to_iupac(oxford):
+def oxford_to_iupac(oxford: str) -> str:
   """converts a glycan from Oxford into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
   | Arguments:
   | :-
   | oxford (string): glycan sequence in Oxford format\n
   | Returns:
   | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form
-  """
+  | Returns glycan as a string in a barebones IUPAC-condensed form"""
   oxford = re.sub(r'\([^)]*\)', '', oxford).strip().split('/')[0]
   antennae = {}
   iupac = "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc"
@@ -828,15 +809,14 @@ def oxford_to_iupac(oxford):
   return iupac
 
 
-def check_nomenclature(glycan):
+def check_nomenclature(glycan: str) -> None:
   """checks whether the proposed glycan has the correct nomenclature for glycowork\n
   | Arguments:
   | :-
   | glycan (string): glycan in IUPAC-condensed format
   | Returns:
   | :-
-  | Prints the reason why it's not convertable
-  """
+  | Prints the reason why it's not convertable"""
   if '@' in glycan:
     print("Seems like you're using SMILES. We currently can only convert IUPAC-->SMILES; not the other way around.")
     return
@@ -846,15 +826,14 @@ def check_nomenclature(glycan):
   return
 
 
-def canonicalize_iupac(glycan):
+def canonicalize_iupac(glycan: str) -> str:
   """converts a glycan from IUPAC-extended, LinearCode, GlycoCT, and WURCS into the exact IUPAC-condensed version that is optimized for glycowork\n
   | Arguments:
   | :-
   | glycan (string): glycan sequence; some rare post-biosynthetic modifications could still be an issue\n
   | Returns:
   | :-
-  | Returns glycan as a string in canonicalized IUPAC-condensed
-  """
+  | Returns glycan as a string in canonicalized IUPAC-condensed"""
   glycan = glycan.strip()
   # Check for different nomenclatures: LinearCode, IUPAC-extended, GlycoCT, WURCS, Oxford
   if ';' in glycan:
@@ -998,7 +977,7 @@ def rescue_compositions(func):
   return wrapper
 
 
-def equal_repeats(r1, r2):
+def equal_repeats(r1: str, r2: str) -> bool:
   """checks whether two repeat units could stem from the same repeating structure, just shifted\n
   | Arguments:
   | :-
@@ -1006,21 +985,19 @@ def equal_repeats(r1, r2):
   | r2 (string): glycan sequence in IUPAC-condensed nomenclature\n
   | Returns:
   | :-
-  | Returns True if repeat structures are shifted versions of each other, else False
-  """
+  | Returns True if repeat structures are shifted versions of each other, else False"""
   r1_long = r1[:r1.rindex(')')+1] * 2
   return any(r1_long[i:i + len(r2)] == r2 for i in range(len(r1)))
 
 
-def infer_features_from_composition(comp):
+def infer_features_from_composition(comp: dict[str, int]) -> dict[str, int]:
   """extracts higher-order glycan features from a composition\n
   | Arguments:
   | :-
   | comp (dict): composition as a dictionary of style monosaccharide : count\n
   | Returns:
   | :-
-  | Returns dictionary containing higher-order glycan features and their absence/presence
-  """
+  | Returns dictionary containing higher-order glycan features and their absence/presence"""
   feature_dic = {}
   if comp.get('A', 0) + comp.get('G', 0) > 1 or comp.get('Neu5Ac', 0) + comp.get('Neu5Gc', 0) > 1:
     feature_dic['complex'] = 1
@@ -1038,7 +1015,7 @@ def infer_features_from_composition(comp):
 
 
 @rescue_compositions
-def parse_glycoform(glycoform, glycan_features = ['H', 'N', 'A', 'F', 'G']):
+def parse_glycoform(glycoform: str | dict[str, int], glycan_features: list[str] = ['H', 'N', 'A', 'F', 'G']) -> dict[str, int]:
   """converts composition of style H5N4F1A2 into monosaccharide counts\n
   | Arguments:
   | :-
@@ -1046,8 +1023,7 @@ def parse_glycoform(glycoform, glycan_features = ['H', 'N', 'A', 'F', 'G']):
   | glycan_features (list): list of extracted glycan features to consider as variables\n
   | Returns:
   | :-
-  | Returns composition as a dictionary of style monosaccharide : count
-  """
+  | Returns composition as a dictionary of style monosaccharide : count"""
   if isinstance(glycoform, dict):
     components = {k: glycoform.get(k, 0) for k in glycan_features}
     return components | infer_features_from_composition(components)
@@ -1058,7 +1034,7 @@ def parse_glycoform(glycoform, glycan_features = ['H', 'N', 'A', 'F', 'G']):
   return components | infer_features_from_composition(components)
 
 
-def process_for_glycoshift(df):
+def process_for_glycoshift(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
   """extracts and formats compositions in glycoproteomics dataset\n
   | Arguments:
   | :-
@@ -1066,8 +1042,7 @@ def process_for_glycoshift(df):
   | Returns:
   | :-
   | (i) glycoproteomics dataset with new columns for protein_site, composition, and composition counts
-  | (ii) list of identified glycan features, such as different monosaccharides
-  """
+  | (ii) list of identified glycan features, such as different monosaccharides"""
   df['Glycosite'] = [k.split('_')[0] + '_' + k.split('_')[1] for i, k in enumerate(df.index)]
   if '[' in df.index[0]:
     comps = ['['+k.split('[')[1] for k in df.index]

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -5,6 +5,7 @@ import re
 from random import choice
 from functools import wraps
 from collections import defaultdict
+from typing import Dict, List, Set, Union, Optional, Callable, Tuple
 from glycowork.glycan_data.loader import (unwrap, multireplace,
                                           find_nth, find_nth_reverse, lib, HexOS, HexNAcOS,
                                           linkages, Hex, HexNAc, dHex, Sia, HexA, Pen)
@@ -32,40 +33,25 @@ monosaccharide_mapping = {
     }
 
 
-def min_process_glycans(glycan_list: list[str]) -> list[list[str]]:
-  """converts list of glycans into a nested lists of glycoletters\n
-  | Arguments:
-  | :-
-  | glycan_list (list): list of glycans in IUPAC-condensed format as strings\n
-  | Returns:
-  | :-
-  | Returns list of glycoletter lists"""
+def min_process_glycans(glycan_list: List[str] # List of glycans in IUPAC-condensed format
+                      ) -> List[List[str]]: # List of glycoletter lists
+  "Convert list of glycans into a nested lists of glycoletters"
   return [[x for x in multireplace(k, {'[': '', ']': '', '{': '', '}': '', ')': '('}).split('(') if x] for k in glycan_list]
 
 
-def get_lib(glycan_list: list[str]) -> dict[str, int]:
-  """returns dictionary of form glycoletter:index\n
-  | Arguments:
-  | :-
-  | glycan_list (list): list of IUPAC-condensed glycan sequences as strings\n
-  | Returns:
-  | :-
-  | Returns dictionary of form glycoletter:index"""
+def get_lib(glycan_list: List[str] # List of IUPAC-condensed glycan sequences
+           ) -> Dict[str, int]: # Dictionary of glycoletter:index mappings
+  "Returns dictionary mapping glycoletters to indices"
   # Convert to glycoletters & flatten & get unique vocab
   lib = sorted(set(unwrap(min_process_glycans(set(glycan_list)))))
   # Convert to dict
   return {k: i for i, k in enumerate(lib)}
 
 
-def expand_lib(libr: dict[str, int], glycan_list: list[str]) -> dict[str, int]:
-  """updates libr with newly introduced glycoletters\n
-  | Arguments:
-  | :-
-  | libr (dict): dictionary of form glycoletter:index
-  | glycan_list (list): list of IUPAC-condensed glycan sequences as strings\n
-  | Returns:
-  | :-
-  | Returns new lib"""
+def expand_lib(libr: Dict[str, int], # Existing dictionary of glycoletter:index
+              glycan_list: List[str] # List of IUPAC-condensed glycan sequences
+             ) -> Dict[str, int]: # Updated dictionary with new glycoletters
+  "Updates libr with newly introduced glycoletters"
   new_libr = get_lib(glycan_list)
   offset = len(libr)
   for k, v in new_libr.items():
@@ -74,55 +60,35 @@ def expand_lib(libr: dict[str, int], glycan_list: list[str]) -> dict[str, int]:
   return libr
 
 
-def in_lib(glycan: str, libr: dict[str, int]) -> bool:
-  """checks whether all glycoletters of glycan are in libr\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed nomenclature
-  | libr (dict): dictionary of form glycoletter:index\n
-  | Returns:
-  | :-
-  | Returns True if all glycoletters are in libr and False if not"""
+def in_lib(glycan: str, # Glycan in IUPAC-condensed nomenclature
+           libr: Dict[str, int] # Dictionary of glycoletter:index
+          ) -> bool: # True if all glycoletters are in libr
+  "Checks whether all glycoletters of glycan are in libr"
   glycan = min_process_glycans([glycan])[0]
   return set(glycan).issubset(libr.keys())
 
 
-def get_possible_linkages(wildcard: str, linkage_list: list[str] = linkages) -> list[str]:
-  """Retrieves all linkages that match a given wildcard pattern from a list of linkages\n
-  | Arguments:
-  | :-
-  | wildcard (string): The pattern to match, where '?' can be used as a wildcard for any single character.
-  | linkage_list (list): List of linkages as strings to search within; default:linkages\n
-  | Returns:
-  | :-
-  | Returns a list of linkages that match the wildcard pattern."""
+def get_possible_linkages(wildcard: str, # Pattern to match, ? can be wildcard
+                         linkage_list: List[str] = linkages # List of linkages to search
+                        ) -> List[str]: # Matching linkages
+  "Retrieves all linkages that match a given wildcard pattern"
   pattern = wildcard.replace("?", r"[a-zA-Z0-9\?]")
   return [linkage for linkage in linkage_list if re.fullmatch(pattern, linkage)]
   #return possible_linkages if libr is None else list(possible_linkages & libr.keys())
 
 
-def get_possible_monosaccharides(wildcard: str) -> set[str]:
-  """Retrieves all matching common monosaccharides of a type, given the type\n
-  | Arguments:
-  | :-
-  | wildcard (string): Monosaccharide type, from "HexNAc", "HexNAcOS", "Hex", "HexOS", "dHex", "Sia", "HexA", "Pen"\n
-  | Returns:
-  | :-
-  | Returns a list of specified monosaccharides of that type"""
+def get_possible_monosaccharides(wildcard: str # Monosaccharide type; options: Hex, HexNAc, dHex, Sia, HexA, Pen, HexOS, HexNAcOS
+                               ) -> Set[str]: # Matching monosaccharides
+  "Retrieves all matching common monosaccharides of a type"
   wildcard_dict = {'Hex': Hex, 'HexNAc': HexNAc, 'dHex': dHex, 'Sia': Sia, 'HexA': HexA, 'Pen': Pen,
                    'HexOS': HexOS, 'HexNAcOS': HexNAcOS,
                    'Monosaccharide': set().union(*[Hex, HexOS, HexNAc, HexNAcOS, dHex, Sia, HexA, Pen])}
   return wildcard_dict.get(wildcard, [])
 
 
-def de_wildcard_glycoletter(glycoletter: str) -> str:
-  """Retrieves a random specified instance of a general type (e.g., "Gal" for "Hex")\n
-  | Arguments:
-  | :-
-  | glycoletter (string): Monosaccharide or linkage\n
-  | Returns:
-  | :-
-  | Returns a random specified glycoletter of that type"""
+def de_wildcard_glycoletter(glycoletter: str # Monosaccharide or linkage with wildcards
+                          ) -> str: # Specific glycoletter instance
+  "Retrieves a random specified instance of a general type (e.g., 'Gal' for 'Hex')"
   if '?' in glycoletter:
     return choice(get_possible_linkages(glycoletter))
   elif monos := get_possible_monosaccharides(glycoletter):
@@ -131,28 +97,18 @@ def de_wildcard_glycoletter(glycoletter: str) -> str:
     return glycoletter
 
 
-def bracket_removal(glycan_part: str) -> str:
-  """iteratively removes (nested) branches between start and end of glycan_part\n
-  | Arguments:
-  | :-
-  | glycan_part (string): residual part of a glycan from within glycan_to_graph\n
-  | Returns:
-  | :-
-  | Returns glycan_part without interfering branches"""
+def bracket_removal(glycan_part: str # Residual part of glycan from glycan_to_graph
+                  ) -> str: # Glycan part without interfering branches
+  "Iteratively removes (nested) branches between start and end of glycan_part"
   regex = re.compile(r'\[[^\[\]]+\]')
   while regex.search(glycan_part):
     glycan_part = regex.sub('', glycan_part)
   return glycan_part
 
 
-def find_isomorphs(glycan: str) -> list[str]:
-  """returns a set of isomorphic glycans by swapping branches etc.\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns list of unique glycan notations (strings) for a glycan in IUPAC-condensed"""
+def find_isomorphs(glycan: str # Glycan in IUPAC-condensed format
+                 ) -> List[str]: # List of isomorphic glycan notations
+  "Returns a set of isomorphic glycans by swapping branches"
   floaty = False
   if '{' in glycan:
     floaty = glycan[:glycan.rindex('}')+1]
@@ -181,23 +137,19 @@ def find_isomorphs(glycan: str) -> list[str]:
   return list(out_list)
 
 
-def presence_to_matrix(df: pd.DataFrame, glycan_col_name: str = 'glycan', 
-                      label_col_name: str = 'Species') -> pd.DataFrame:
-  """converts a dataframe such as df_species to absence/presence matrix\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycan occurrence, rows are glycan-label pairs
-  | glycan_col_name (string): column name under which glycans are stored; default:glycan
-  | label_col_name (string): column name under which labels are stored; default:Species\n
-  | Returns:
-  | :-
-  | Returns pandas dataframe with labels as rows and glycan occurrences as columns"""
+def presence_to_matrix(df: pd.DataFrame, # DataFrame with glycan occurrence
+                      glycan_col_name: str = 'glycan', # Column name for glycans
+                      label_col_name: str = 'Species' # Column name for labels
+                     ) -> pd.DataFrame: # Matrix with labels as rows and glycan occurrences as columns
+  "Converts a dataframe with glycan occurrence to absence/presence matrix"
   # Create a grouped dataframe where we count the occurrences of each glycan in each species group
   grouped_df = df.groupby([label_col_name, glycan_col_name]).size().unstack(fill_value = 0)
   return grouped_df.sort_index().sort_index(axis = 1)
 
 
-def find_matching_brackets_indices(s: str) -> list[tuple[int, int]] | None:
+def find_matching_brackets_indices(s: str # String containing brackets
+                                ) -> Optional[List[Tuple[int, int]]]: # List of (opening, closing) bracket indices or None
+  "Find pairs of matching brackets in a string"
   stack = []
   matching_indices = []
   for i, c in enumerate(s):
@@ -215,15 +167,10 @@ def find_matching_brackets_indices(s: str) -> list[tuple[int, int]] | None:
     return matching_indices
 
 
-def choose_correct_isoform(glycans: list[str], reverse: bool = False) -> str | list[str]:
-  """given a list of glycan branch isomers, this function returns the correct isomer\n
-  | Arguments:
-  | :-
-  | glycans (list): glycans in IUPAC-condensed nomenclature
-  | reverse (bool): whether to return the correct isomer (False) or everything except the correct isomer (True); default:False\n
-  | Returns:
-  | :-
-  | Returns the correct isomer as a string (if reverse=False; otherwise it returns a list of strings)"""
+def choose_correct_isoform(glycans: List[str], # Glycans in IUPAC-condensed nomenclature
+                         reverse: bool = False # Return non-correct isomers instead; default:False
+                        ) -> Union[str, List[str]]: # Correct isomer (str) or non-correct isomers (List[str])
+  "Given a list of glycan branch isomers, returns the correct isomer"
   glycans = list(set(glycans))
   if '?' in ''.join(glycans) and not reverse:
     min_questions = min(glycan.count('?') for glycan in glycans)
@@ -289,17 +236,12 @@ def choose_correct_isoform(glycans: list[str], reverse: bool = False) -> str | l
   return correct_isoform
 
 
-def enforce_class(glycan: str, glycan_class: str, conf: float | None = None, extra_thresh: float = 0.3) -> bool:
-  """given a glycan and glycan class, determines whether glycan is from this class\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed nomenclature
-  | glycan_class (string): glycan class in form of "O", "N", "free", or "lipid"
-  | conf (float): prediction confidence; can be used to override class
-  | extra_thresh (float): threshold to override class; default:0.3\n
-  | Returns:
-  | :-
-  | Returns True if glycan is in glycan class and False if not"""
+def enforce_class(glycan: str, # Glycan in IUPAC-condensed nomenclature
+                 glycan_class: str, # Glycan class (O, N, free, or lipid)
+                 conf: Optional[float] = None, # Prediction confidence to override class
+                 extra_thresh: float = 0.3 # Threshold to override class
+                ) -> bool: # True if glycan is in glycan class
+  "Determines whether glycan belongs to a specified class"
   pools = {
     'O': 'GalNAc|GalNAcOS|GalNAc[46]S|Man|Fuc|Gal|GlcNAc|GlcNAcOS|GlcNAc6S',
     'N': 'GlcNAc',
@@ -315,14 +257,9 @@ def enforce_class(glycan: str, glycan_class: str, conf: float | None = None, ext
   return conf > extra_thresh if not truth and conf is not None else truth
 
 
-def get_class(glycan: str) -> str:
-  """given a glycan, determines its class\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed nomenclature\n
-  | Returns:
-  | :-
-  | Returns "O", "N", "free", or "lipid" (or empty string if not either)"""
+def get_class(glycan: str # Glycan in IUPAC-condensed nomenclature
+            ) -> str: # Glycan class (O, N, free, lipid, or empty)
+  "Determines glycan class"
   if glycan.endswith('-ol'):
     return 'free'
   if glycan.endswith(('1Cer', 'Ins')):
@@ -334,14 +271,9 @@ def get_class(glycan: str) -> str:
   return ''
 
 
-def canonicalize_composition(comp: str) -> dict[str, int]:
-  """converts a composition from any common format into the dictionary that is optimized for glycowork\n
-  | Arguments:
-  | :-
-  | comp (string): composition formatted either in the style of Hex5HexNAc4Fuc1Neu5Ac2 or H5N4F1A2\n
-  | Returns:
-  | :-
-  | Returns composition as a dictionary of style monosaccharide : count"""
+def canonicalize_composition(comp: str # Composition in Hex5HexNAc4Fuc1Neu5Ac2 or H5N4F1A2 format
+                          ) -> Dict[str, int]: # Dictionary of monosaccharide:count
+  "Converts composition from any common format to standardized dictionary"
   if '_' in comp:
     values = comp.split('_')
     temp = {"Hex": int(values[0]), "HexNAc": int(values[1]), "Neu5Ac": int(values[2]), "dHex": int(values[3])}
@@ -388,14 +320,9 @@ def canonicalize_composition(comp: str) -> dict[str, int]:
   return comp_dict
 
 
-def IUPAC_to_SMILES(glycan_list: list[str]) -> list[str]:
-  """given a list of IUPAC-condensed glycans, uses GlyLES to return a list of corresponding isomeric SMILES\n
-  | Arguments:
-  | :-
-  | glycan_list (list): list of IUPAC-condensed glycans\n
-  | Returns:
-  | :-
-  | Returns a list of corresponding isomeric SMILES"""
+def IUPAC_to_SMILES(glycan_list: List[str] # List of IUPAC-condensed glycans
+                   ) -> List[str]: # List of corresponding SMILES strings
+  "Convert list of IUPAC-condensed glycans to isomeric SMILES using GlyLES"
   try:
     from glyles import convert
   except ImportError:
@@ -405,14 +332,9 @@ def IUPAC_to_SMILES(glycan_list: list[str]) -> list[str]:
   return [convert(g)[0][1] for g in glycan_list]
 
 
-def linearcode_to_iupac(linearcode: str) -> str:
-  """converts a glycan from LinearCode into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
-  | Arguments:
-  | :-
-  | linearcode (string): glycan sequence in LinearCode format\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form"""
+def linearcode_to_iupac(linearcode: str # Glycan in LinearCode format
+                      ) -> str: # Basic IUPAC-condensed format
+  "Convert glycan from LinearCode to barebones IUPAC-condensed format"
   replace_dic = {'G': 'Glc', 'ME': 'me', 'M': 'Man', 'A': 'Gal', 'NN': 'Neu5Ac', 'GlcN': 'GlcNAc', 'GN': 'GlcNAc',
                  'GalN': 'GalNAc', 'AN': 'GalNAc', 'F': 'Fuc', 'K': 'Kdn', 'W': 'Kdo', 'L': 'GalA', 'I': 'IdoA', 'PYR': 'Pyr', 'R': 'Araf', 'H': 'Rha',
                  'X': 'Xyl', 'B': 'Rib', 'U': 'GlcA', 'O': 'All', 'E': 'Fruf', '[': '', ']': '', 'me': 'Me', 'PC': 'PCho', 'T': 'Ac'}
@@ -420,14 +342,9 @@ def linearcode_to_iupac(linearcode: str) -> str:
   return glycan
 
 
-def iupac_extended_to_condensed(iupac_extended: str) -> str:
-  """converts a glycan from IUPAC-extended into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
-  | Arguments:
-  | :-
-  | iupac_extended (string): glycan sequence in IUPAC-extended format\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form"""
+def iupac_extended_to_condensed(iupac_extended: str # Glycan in IUPAC-extended format
+                             ) -> str: # Basic IUPAC-condensed format
+  "Convert glycan from IUPAC-extended to barebones IUPAC-condensed format"
   # Find all occurrences of the pattern and apply the changes
   def replace_pattern(match):
     # Move the α or β after the next opening parenthesis
@@ -442,8 +359,11 @@ def iupac_extended_to_condensed(iupac_extended: str) -> str:
   return adjusted_string[:adjusted_string.rindex('(')]
 
 
-def glycoct_to_iupac_int(glycoct: str, mono_replace: dict[str, str], sub_replace: dict[str, str]) -> tuple[dict[int, str], 
-                                                            dict[int, list[tuple[str, int]]], dict[int, int]]:
+def glycoct_to_iupac_int(glycoct: str, # GlycoCT format string
+                        mono_replace: Dict[str, str], # Monosaccharide replacement mappings
+                        sub_replace: Dict[str, str] # Substituent replacement mappings
+                       ) -> Tuple[Dict[int, str], Dict[int, List[Tuple[str, int]]], Dict[int, int]]: # (Residue dict, IUPAC parts, Degrees)
+  "Internal function for GlycoCT conversion"
   # Dictionaries to hold the mapping of residues and linkages
   residue_dic = {}
   iupac_parts = defaultdict(list)
@@ -499,8 +419,11 @@ def glycoct_to_iupac_int(glycoct: str, mono_replace: dict[str, str], sub_replace
   return residue_dic, iupac_parts, degrees
 
 
-def glycoct_build_iupac(iupac_parts: dict[int, list[tuple[str, int]]], 
-                       residue_dic: dict[int, str], degrees: dict[int, int]) -> str:
+def glycoct_build_iupac(iupac_parts: Dict[int, List[Tuple[str, int]]], # IUPAC format components
+                       residue_dic: Dict[int, str], # Residue mappings
+                       degrees: Dict[int, int] # Node degrees
+                      ) -> str: # IUPAC-condensed format
+  "Build IUPAC string from GlycoCT components"
   start = min(residue_dic.keys())
   iupac = residue_dic[start]
   inverted_residue_dic = {}
@@ -533,14 +456,9 @@ def glycoct_build_iupac(iupac_parts: dict[int, list[tuple[str, int]]],
   return iupac.strip('[]')
 
 
-def glycoct_to_iupac(glycoct: str) -> str:
-  """converts a glycan from GlycoCT into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
-  | Arguments:
-  | :-
-  | glycoct (string): glycan sequence in GlycoCT format\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form"""
+def glycoct_to_iupac(glycoct: str # Glycan in GlycoCT format
+                    ) -> str: # Basic IUPAC-condensed format
+  "Convert glycan from GlycoCT to barebones IUPAC-condensed format"
   floating_bits = []
   floating_part = ''
   mono_replace = {'dglc': 'Glc', 'dgal': 'Gal', 'dman': 'Man', 'lgal': 'Fuc', 'dgro': 'Neu',
@@ -575,14 +493,9 @@ def glycoct_to_iupac(glycoct: str) -> str:
   return iupac
 
 
-def get_mono(token: str) -> str:
-  """maps WURCS token to monosaccharide with anomeric state; provides anomeric flexibility\n
-  | Arguments:
-  | :-
-  | token (string): token indicating monosaccharide in WURCS format\n
-  | Returns:
-  | :-
-  | Returns monosaccharide with anomeric state as string"""
+def get_mono(token: str # WURCS monosaccharide token
+           ) -> str: # Monosaccharide with anomeric state
+  "Map WURCS token to monosaccharide with anomeric state"
   anomer = token[token.index('_')-1]
   if token in monosaccharide_mapping:
     mono = monosaccharide_mapping[token]
@@ -599,14 +512,9 @@ def get_mono(token: str) -> str:
   return mono
 
 
-def wurcs_to_iupac(wurcs: str) -> str:
-  """converts a glycan from WURCS into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
-  | Arguments:
-  | :-
-  | wurcs (string): glycan sequence in WURCS format\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form"""
+def wurcs_to_iupac(wurcs: str # Glycan in WURCS format
+                  ) -> str: # Basic IUPAC-condensed format
+  "Convert glycan from WURCS to barebones IUPAC-condensed format"
   wurcs = wurcs[wurcs.index('/')+1:]
   pattern = r'\b([a-z])\d(?:\|\1\d)+\}?|\b[a-z](\d)(?:\|[a-z]\2)+\}?'
   additional_pattern = r'\b([a-z])\?(?:\|\w\?)+\}?'
@@ -690,14 +598,9 @@ def wurcs_to_iupac(wurcs: str) -> str:
   return iupac
 
 
-def oxford_to_iupac(oxford: str) -> str:
-  """converts a glycan from Oxford into a barebones IUPAC-condensed version that is cleaned up by canonicalize_iupac\n
-  | Arguments:
-  | :-
-  | oxford (string): glycan sequence in Oxford format\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in a barebones IUPAC-condensed form"""
+def oxford_to_iupac(oxford: str # Glycan in Oxford format
+                   ) -> str: # Glycan in IUPAC-condensed format
+  "Convert glycan from Oxford to IUPAC-condensed format"
   oxford = re.sub(r'\([^)]*\)', '', oxford).strip().split('/')[0]
   antennae = {}
   iupac = "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc"
@@ -809,14 +712,9 @@ def oxford_to_iupac(oxford: str) -> str:
   return iupac
 
 
-def check_nomenclature(glycan: str) -> None:
-  """checks whether the proposed glycan has the correct nomenclature for glycowork\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | Returns:
-  | :-
-  | Prints the reason why it's not convertable"""
+def check_nomenclature(glycan: str # Glycan string to check
+                     ) -> None: # Prints reason if not convertible
+  "Check whether glycan has correct nomenclature for glycowork"
   if '@' in glycan:
     print("Seems like you're using SMILES. We currently can only convert IUPAC-->SMILES; not the other way around.")
     return
@@ -826,14 +724,9 @@ def check_nomenclature(glycan: str) -> None:
   return
 
 
-def canonicalize_iupac(glycan: str) -> str:
-  """converts a glycan from IUPAC-extended, LinearCode, GlycoCT, and WURCS into the exact IUPAC-condensed version that is optimized for glycowork\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan sequence; some rare post-biosynthetic modifications could still be an issue\n
-  | Returns:
-  | :-
-  | Returns glycan as a string in canonicalized IUPAC-condensed"""
+def canonicalize_iupac(glycan: str # Glycan sequence in any supported format
+                     ) -> str: # Standardized IUPAC-condensed format
+  "Convert glycan from IUPAC-extended, LinearCode, GlycoCT, and WURCS to standardized IUPAC-condensed format"
   glycan = glycan.strip()
   # Check for different nomenclatures: LinearCode, IUPAC-extended, GlycoCT, WURCS, Oxford
   if ';' in glycan:
@@ -949,7 +842,9 @@ def canonicalize_iupac(glycan: str) -> str:
   return glycan
 
 
-def rescue_glycans(func):
+def rescue_glycans(func: Callable # Function to wrap
+                 ) -> Callable: # Wrapped function handling formatting issues
+  "Decorator for handling malformed glycan sequences"
   @wraps(func)
   def wrapper(*args, **kwargs):
     try:
@@ -963,7 +858,9 @@ def rescue_glycans(func):
   return wrapper
 
 
-def rescue_compositions(func):
+def rescue_compositions(func: Callable # Function to wrap
+                      ) -> Callable: # Wrapped function handling composition format issues
+  "Decorator for handling malformed glycan compositions"
   @wraps(func)
   def wrapper(*args, **kwargs):
     try:
@@ -977,27 +874,17 @@ def rescue_compositions(func):
   return wrapper
 
 
-def equal_repeats(r1: str, r2: str) -> bool:
-  """checks whether two repeat units could stem from the same repeating structure, just shifted\n
-  | Arguments:
-  | :-
-  | r1 (string): glycan sequence in IUPAC-condensed nomenclature
-  | r2 (string): glycan sequence in IUPAC-condensed nomenclature\n
-  | Returns:
-  | :-
-  | Returns True if repeat structures are shifted versions of each other, else False"""
+def equal_repeats(r1: str, # First glycan sequence
+                 r2: str # Second glycan sequence
+                ) -> bool: # True if repeats are shifted versions
+  "Check whether two repeat units could stem from the same repeating structure"
   r1_long = r1[:r1.rindex(')')+1] * 2
   return any(r1_long[i:i + len(r2)] == r2 for i in range(len(r1)))
 
 
-def infer_features_from_composition(comp: dict[str, int]) -> dict[str, int]:
-  """extracts higher-order glycan features from a composition\n
-  | Arguments:
-  | :-
-  | comp (dict): composition as a dictionary of style monosaccharide : count\n
-  | Returns:
-  | :-
-  | Returns dictionary containing higher-order glycan features and their absence/presence"""
+def infer_features_from_composition(comp: Dict[str, int] # Composition dictionary of monosaccharide:count
+                                 ) -> Dict[str, int]: # Dictionary of features and presence/absence
+  "Extract higher-order glycan features from a composition"
   feature_dic = {}
   if comp.get('A', 0) + comp.get('G', 0) > 1 or comp.get('Neu5Ac', 0) + comp.get('Neu5Gc', 0) > 1:
     feature_dic['complex'] = 1
@@ -1015,15 +902,10 @@ def infer_features_from_composition(comp: dict[str, int]) -> dict[str, int]:
 
 
 @rescue_compositions
-def parse_glycoform(glycoform: str | dict[str, int], glycan_features: list[str] = ['H', 'N', 'A', 'F', 'G']) -> dict[str, int]:
-  """converts composition of style H5N4F1A2 into monosaccharide counts\n
-  | Arguments:
-  | :-
-  | comp (string): composition formatted either in the style of Hex5HexNAc4Fuc1Neu5Ac2 or H5N4F1A2
-  | glycan_features (list): list of extracted glycan features to consider as variables\n
-  | Returns:
-  | :-
-  | Returns composition as a dictionary of style monosaccharide : count"""
+def parse_glycoform(glycoform: Union[str, Dict[str, int]], # Composition in H5N4F1A2 format or dict
+                   glycan_features: List[str] = ['H', 'N', 'A', 'F', 'G'] # Features to extract
+                  ) -> Dict[str, int]: # Dictionary of feature counts
+  "Convert composition like H5N4F1A2 into monosaccharide counts"
   if isinstance(glycoform, dict):
     components = {k: glycoform.get(k, 0) for k in glycan_features}
     return components | infer_features_from_composition(components)
@@ -1034,15 +916,9 @@ def parse_glycoform(glycoform: str | dict[str, int], glycan_features: list[str] 
   return components | infer_features_from_composition(components)
 
 
-def process_for_glycoshift(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
-  """extracts and formats compositions in glycoproteomics dataset\n
-  | Arguments:
-  | :-
-  | df (dataframe): glycoproteomics dataset, expects index to be formatted as protein_site_composition\n
-  | Returns:
-  | :-
-  | (i) glycoproteomics dataset with new columns for protein_site, composition, and composition counts
-  | (ii) list of identified glycan features, such as different monosaccharides"""
+def process_for_glycoshift(df: pd.DataFrame # Dataset with protein_site_composition index
+                         ) -> Tuple[pd.DataFrame, List[str]]: # (Modified dataset with new columns for protein_site, composition, and composition counts, glycan features)
+  "Extract and format compositions in glycoproteomics dataset"
   df['Glycosite'] = [k.split('_')[0] + '_' + k.split('_')[1] for i, k in enumerate(df.index)]
   if '[' in df.index[0]:
     comps = ['['+k.split('[')[1] for k in df.index]

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -299,7 +299,7 @@ def choose_correct_isoform(glycans, reverse = False):
     correct_isoform = glycans
   return correct_isoform
 
-  
+
 def enforce_class(glycan, glycan_class, conf = None, extra_thresh = 0.3):
   """given a glycan and glycan class, determines whether glycan is from this class\n
   | Arguments:

--- a/glycowork/motif/query.py
+++ b/glycowork/motif/query.py
@@ -1,17 +1,16 @@
 import numpy as np
 import pandas as pd
+from typing import List, Optional
 
 from glycowork.glycan_data.loader import motif_list, df_glycan
 from glycowork.motif.graph import compare_glycans
 from glycowork.motif.annotate import annotate_glycan
 
 
-def get_insight(glycan: str, motifs: pd.DataFrame | None = None) -> None:
-    """prints out meta-information about a glycan\n
-    | Arguments:
-    | :-
-    | glycan (string): glycan in IUPAC-condensed format
-    | motifs (dataframe): dataframe of glycan motifs (name + sequence); default:motif_list\n"""
+def get_insight(glycan: str, # Glycan in IUPAC-condensed format
+                motifs: Optional[pd.DataFrame] = None # DataFrame of glycan motifs; default:motif_list
+               ) -> None: # Prints glycan meta-information
+    "Print meta-information about a glycan"
     if motifs is None:
         motifs = motif_list
     print("Let's get rolling! Give us a few moments to crunch some numbers.")
@@ -48,15 +47,10 @@ def get_insight(glycan: str, motifs: pd.DataFrame | None = None) -> None:
     print("\nThat's all we can do for you at this point!")
 
 
-def glytoucan_to_glycan(ids: list[str], revert: bool = False) -> list[str]:
-    """interconverts GlyTouCan IDs and glycans in IUPAC-condensed\n
-    | Arguments:
-    | :-
-    | ids (list): list of GlyTouCan IDs as strings (if using glycans instead, change 'revert' to True
-    | revert (bool): whether glycans should be mapped to GlyTouCan IDs or vice versa; default:False\n
-    | Returns:
-    | :-
-    | Returns list of either GlyTouCan IDs or glycans in IUPAC-condensed"""
+def glytoucan_to_glycan(ids: List[str], # List of GlyTouCan IDs or glycans
+                       revert: bool = False # Whether to map glycans to IDs; default:False
+                      ) -> List[str]: # List of glycans or IDs
+    "Convert between GlyTouCan IDs and IUPAC-condensed glycans"
     if revert:
         ids = [df_glycan.glytoucan_id.values.tolist()[df_glycan.glycan.values.tolist().index(k)[0]] for k in ids]
         if any([k not in df_glycan.glycan.values.tolist() for k in ids]):

--- a/glycowork/motif/query.py
+++ b/glycowork/motif/query.py
@@ -1,17 +1,17 @@
 import numpy as np
+import pandas as pd
 
 from glycowork.glycan_data.loader import motif_list, df_glycan
 from glycowork.motif.graph import compare_glycans
 from glycowork.motif.annotate import annotate_glycan
 
 
-def get_insight(glycan, motifs = None):
+def get_insight(glycan: str, motifs: pd.DataFrame | None = None) -> None:
     """prints out meta-information about a glycan\n
     | Arguments:
     | :-
     | glycan (string): glycan in IUPAC-condensed format
-    | motifs (dataframe): dataframe of glycan motifs (name + sequence); default:motif_list\n
-    """
+    | motifs (dataframe): dataframe of glycan motifs (name + sequence); default:motif_list\n"""
     if motifs is None:
         motifs = motif_list
     print("Let's get rolling! Give us a few moments to crunch some numbers.")
@@ -48,7 +48,7 @@ def get_insight(glycan, motifs = None):
     print("\nThat's all we can do for you at this point!")
 
 
-def glytoucan_to_glycan(ids, revert = False):
+def glytoucan_to_glycan(ids: list[str], revert: bool = False) -> list[str]:
     """interconverts GlyTouCan IDs and glycans in IUPAC-condensed\n
     | Arguments:
     | :-
@@ -56,8 +56,7 @@ def glytoucan_to_glycan(ids, revert = False):
     | revert (bool): whether glycans should be mapped to GlyTouCan IDs or vice versa; default:False\n
     | Returns:
     | :-
-    | Returns list of either GlyTouCan IDs or glycans in IUPAC-condensed
-    """
+    | Returns list of either GlyTouCan IDs or glycans in IUPAC-condensed"""
     if revert:
         ids = [df_glycan.glytoucan_id.values.tolist()[df_glycan.glycan.values.tolist().index(k)[0]] for k in ids]
         if any([k not in df_glycan.glycan.values.tolist() for k in ids]):

--- a/glycowork/motif/regex.py
+++ b/glycowork/motif/regex.py
@@ -2,19 +2,15 @@ import re
 import copy
 import networkx as nx
 from itertools import product, combinations, chain
+from typing import Dict, List, Union, Optional, Tuple, Callable, Any
 from glycowork.glycan_data.loader import replace_every_second, unwrap
 from glycowork.motif.processing import min_process_glycans, bracket_removal, canonicalize_iupac
 from glycowork.motif.graph import graph_to_string, subgraph_isomorphism, compare_glycans, glycan_to_nxGraph
 
 
-def preprocess_pattern(pattern: str) -> list[str]:
-  """transforms a glyco-regular expression into chunks\n
-  | Arguments:
-  | :-
-  | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
-  | Returns:
-  | :-
-  | Returns list of chunks to be used by downstream functions"""
+def preprocess_pattern(pattern: str # Glyco-regular expression like "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"
+                     ) -> List[str]: # List of pattern chunks
+  "Transform glyco-regular expression into chunks"
   # Use regular expression to identify the conditional parts and keep other chunks together
   pattern = pattern.replace('.', 'Monosaccharide')
   components = re.split(r'(-?\s*\(?\[.*?\]\)?\s*(?:\{,?\d*,?\d*\}\?|\{,?\d*,?\d*\}|\*\?|\+\?|\?|\*|\+)\s*-?)', pattern)
@@ -22,14 +18,9 @@ def preprocess_pattern(pattern: str) -> list[str]:
   return [x.strip('-').strip() for x in components if x]
 
 
-def specify_linkages(pattern_component: str) -> str:
-  """allows for specification of exact linkages by converting expressions such as Mana6 to Man(a1-6)\n
-  | Arguments:
-  | :-
-  | pattern_component (string): chunk of a glyco-regular expression\n
-  | Returns:
-  | :-
-  | Returns specified chunk to be used by downstream functions"""
+def specify_linkages(pattern_component: str # Chunk of glyco-regular expression
+                   ) -> str: # Specified component with linkages
+  "Convert expression linkages from shorthand to full notation, such as Mana6 to Man(a1-6)"
   if re.search(r"[\d|\?]\(|\d$", pattern_component):
     pattern = re.compile(r"([ab\?])([2-9\?])\(\?1-\?\)")
     def replacer(match):
@@ -39,33 +30,25 @@ def specify_linkages(pattern_component: str) -> str:
   return pattern_component.replace('5Ac(a1', '5Ac(a2').replace('5Gc(a1', '5Gc(a2').replace('Kdn(a1', 'Kdn(a2').replace('Sia(a1', 'Sia(a2')
 
 
-def replace_patterns(s: str) -> str:
+def replace_patterns(s: str # String to process
+                   ) -> str: # Processed string
+  "Replace pattern strings with standardized forms"
   return s.replace('-', '(?1-?)').replace('5Ac(?1', '5Ac(?2').replace('5Gc(?1', '5Gc(?2')
 
 
-def process_occurrence(occ_str: str) -> list[int]:
-  """processes the minimum and maximum occurrence of a pattern component\n
-  | Arguments:
-  | :-
-  | occ_str (string): content between {} of a pattern component\n
-  | Returns:
-  | :-
-  | Returns list of minimum and maximum occurrence"""
+def process_occurrence(occ_str: str # Content between {} of pattern component
+                     ) -> List[int]: # [min_occurrence, max_occurrence]
+  "Process min/max occurrence of pattern component"
   occ = occ_str.split(',')
   if len(occ) == 1:
     return [int(occ[0]), int(occ[0])]
   return [int(occ[0]) if occ[0] else 0, int(occ[1]) if occ[1] else 5]
 
 
-def process_question_mark(s: str, p: str) -> tuple[list[int], list[str]]:
-  """processes pattern components with lookahead/-behind or just regular ? characters\n
-  | Arguments:
-  | :-
-  | s (string): original pattern component
-  | p (string): content between [] in pattern component\n
-  | Returns:
-  | :-
-  | Returns list of minimum and maximum occurrence + cleaned up pattern component"""
+def process_question_mark(s: str, # Original pattern component
+                        p: str # Content between [] in pattern
+                       ) -> Tuple[List[int], List[str]]: # ([occurrences], [patterns])
+  "Process components with lookahead/behind or ? characters"
   if '?<' in s:
     occurrence = [1]
     part = s.split('=')[1].replace(')', '') if '=' in s else s.split(')')[1]
@@ -79,14 +62,9 @@ def process_question_mark(s: str, p: str) -> tuple[list[int], list[str]]:
   return occurrence, pattern
 
 
-def expand_pattern(pattern_component: str) -> list[str]:
-  """allows for specification of ambiguous (but not wildcarded) linkages by converting expressions such as Galb3/4 to the two specified versions\n
-  | Arguments:
-  | :-
-  | pattern_component (string): chunk of a glyco-regular expression\n
-  | Returns:
-  | :-
-  | Returns a list of specified pattern components, ready for specify_linkages etc."""
+def expand_pattern(pattern_component: str # Chunk of glyco-regular expression
+                 ) -> List[str]: # List of specified components
+  "Expand ambiguous (but not wildcarded) linkages into specific versions; e.g., Galb3/4 to the two specified versions"
   # Find the window of ambiguity (a segment with characters separated by slashes)
   match = re.findall(r'\d\/\d', pattern_component)
   if not match:
@@ -98,14 +76,9 @@ def expand_pattern(pattern_component: str) -> list[str]:
   return [pattern_component.replace(ambiguous_window, char, 1) for char in ambiguous_chars]
 
 
-def convert_pattern_component(pattern_component: str) -> str | dict[str, list[int]]:
-  """processes a pattern component into either a string or dict of form string : occurrence\n
-  | Arguments:
-  | :-
-  | pattern_component (string): chunk of a glyco-regular expression\n
-  | Returns:
-  | :-
-  | Returns a string for simple components and a dict of form string : occurrence for complex components"""
+def convert_pattern_component(pattern_component: str # Chunk of glyco-regular expression
+                           ) -> Union[str, Dict[str, List[int]]]: # String or dict mapping to occurrences
+  "Process pattern component into string or occurrence dictionary"
   if not any([k in pattern_component for k in ['[', '{', '*', '+', '=', '<!', '?!']]):
     if pattern_component[-1].isdigit() or pattern_component[-1] == '?':
       pattern_component += '-'
@@ -136,15 +109,10 @@ def convert_pattern_component(pattern_component: str) -> str | dict[str, list[in
   return {specify_linkages(p): occurrence for p in pattern}
 
 
-def process_main_branch(glycan: str, glycan_parts: list[str]) -> list[str]:
-  """extracts the main chain node indices of a glycan\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan sequence in IUPAC-condensed
-  | glycan_parts (list): list of glycoletters as returned by min_process_glycans\n
-  | Returns:
-  | :-
-  | Returns a list of node indices, in which node indices not belonging to the main chain have been replaced by empty strings"""
+def process_main_branch(glycan: str, # Glycan in IUPAC-condensed
+                       glycan_parts: List[str] # List of glycoletters as returned by min_process_glycans
+                      ) -> List[str]: # Node index list with non-main chain nodes as empty strings
+  "Extract main chain node indices of glycan"
   glycan_dic = {i:p for i,p in enumerate(glycan_parts)}
   glycan2 = bracket_removal(glycan)
   glycan_parts2 = min_process_glycans([glycan2])[0]
@@ -160,16 +128,11 @@ def process_main_branch(glycan: str, glycan_parts: list[str]) -> list[str]:
   return list(glycan_dic.values())
 
 
-def check_negative_look(matches: list[list[int]], pattern: str, glycan: str) -> list[list[int]]:
-  """filters the matches by whether they fulfill the negative lookahead/-behind condition\n
-  | Arguments:
-  | :-
-  | matches (list): list of lists of node indices for each match
-  | pattern (string): glyco-regular expression
-  | glycan (string): glycan sequence in IUPAC-condensed\n
-  | Returns:
-  | :-
-  | Returns a filtered list of matches"""
+def check_negative_look(matches: List[List[int]], # List of node index lists for matches
+                       pattern: str, # Glyco-regular expression
+                       glycan: str # Glycan in IUPAC-condensed
+                      ) -> List[List[int]]: # Filtered matches
+  "Filter matches by negative lookahead/behind conditions"
   glycan_parts = min_process_glycans([glycan])[0]
   glycan_parts_main = process_main_branch(glycan, glycan_parts)
   part = convert_pattern_component(pattern.split('!')[1].split(')')[0])
@@ -196,16 +159,11 @@ def check_negative_look(matches: list[list[int]], pattern: str, glycan: str) -> 
   return [m for i, m in enumerate(matches) if not compare_glycans(target_locs[i], part)]
 
 
-def filter_matches_by_location(matches: list[list[int]], ggraph: nx.Graph, match_location: str | None) -> list[list[int]]:
-  """filters the matches by whether they fulfill the location condition (start/end)\n
-  | Arguments:
-  | :-
-  | matches (list): list of lists of node indices for each match
-  | ggraph (networkx): glycan graph as a networkx object
-  | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
-  | Returns:
-  | :-
-  | Returns a filtered list of matches"""
+def filter_matches_by_location(matches: List[List[int]], # List of node index lists
+                             ggraph: nx.Graph, # Glycan graph
+                             match_location: Optional[str] # Location to match: start/end/internal
+                            ) -> List[List[int]]: # Filtered matches
+  "Filter matches by location requirement"
   if matches and matches[0] and matches[0][0] and isinstance(matches[0][0], list):
     matches = unwrap(matches)
   if match_location == 'start':
@@ -219,16 +177,11 @@ def filter_matches_by_location(matches: list[list[int]], ggraph: nx.Graph, match
   return matches
 
 
-def process_simple_pattern(p2: nx.Graph, ggraph: nx.Graph, match_location: str | None) -> list[list[int]] | bool:
-  """for just a straight-up glycomotif, checks whether and where it can be found in glycan\n
-  | Arguments:
-  | :-
-  | p2 (networkx): glycomotif graph as a networkx object
-  | ggraph (networkx): glycan graph as a networkx object
-  | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
-  | Returns:
-  | :-
-  | Returns list of matches as list of node indices"""
+def process_simple_pattern(p2: nx.Graph, # Glycomotif graph
+                         ggraph: nx.Graph, # Glycan graph
+                         match_location: Optional[str] # Location to match: start/end/internal
+                        ) -> Union[List[List[int]], bool]: # Match node indices or False
+  "Check if simple glycomotif exists in glycan"
   res = subgraph_isomorphism(ggraph, p2, return_matches = True)
   if not res:
     return False
@@ -242,14 +195,9 @@ def process_simple_pattern(p2: nx.Graph, ggraph: nx.Graph, match_location: str |
   return [m for m in matches if all(x < y for x, y in zip(m, m[1:]))]
 
 
-def calculate_len_matches_comb(len_matches: list[list[int]]) -> list[int]:
-  """takes a list of lengths of the matched sequences, returns a list of lengths considering the combination of the matches\n
-  | Arguments:
-  | :-
-  | len_matches (list): list of match lengths\n
-  | Returns:
-  | :-
-  | Returns list of lengths of possible combinations of matches"""
+def calculate_len_matches_comb(len_matches: List[List[int]] # List of match lengths
+                            ) -> List[int]: # Combined match lengths
+  "Calculate lengths considering combinations of matches"
   if not len_matches:
     return [0]
   if len(len_matches) == 1:
@@ -261,19 +209,13 @@ def calculate_len_matches_comb(len_matches: list[list[int]]) -> list[int]:
     return list(set(unwrap(len_matches) + [sum(combination) for combination in cartesian_product]))
 
 
-def process_complex_pattern(p: str, p2: dict[str, list[int]], ggraph: nx.Graph,
-                          glycan: str, match_location: str | None) -> list[list[int]] | bool:
-  """for a glycomotif with regular expression modifiers, checks whether and where it can be found in glycan\n
-  | Arguments:
-  | :-
-  | p (string): pattern component describing the glycomotif
-  | p2 (dict): dictionary of form glycomotif : occurrence
-  | ggraph (networkx): glycan graph as a networkx object
-  | glycan (string): glycan sequence in IUPAC-condensed
-  | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
-  | Returns:
-  | :-
-  | Returns list of matches as list of node indices"""
+def process_complex_pattern(p: str, # Pattern component
+                          p2: Dict[str, List[int]], # Dict mapping pattern to occurrences
+                          ggraph: nx.Graph, # Glycan graph
+                          glycan: str, # Glycan in IUPAC-condensed
+                          match_location: Optional[str] # Location to match: start/end/internal
+                         ) -> Union[List[List[int]], bool]: # Match node indices or False
+  "Check if complex glycomotif, containing regular expression modifiers, exists in glycan"
   if not any('-' in p_key for p_key in p2.keys()):
     p2_keys = [specify_linkages(replace_patterns(p_key + '-' if p_key[-1].isdigit() or p_key[-1] == '?' else p_key)) for p_key in p2.keys()]
   else:
@@ -315,31 +257,21 @@ def process_complex_pattern(p: str, p2: dict[str, list[int]], ggraph: nx.Graph,
   return matches
 
 
-def process_pattern(p: str, p2: str | dict[str, list[int]], ggraph: nx.Graph, glycan: str, match_location: str | None) -> list[list[int]] | bool:
-  """for a glycomotif, checks whether and where it can be found in glycan\n
-  | Arguments:
-  | :-
-  | p (string): pattern component describing the glycomotif
-  | p2 (dict): dictionary of form glycomotif : occurrence
-  | ggraph (networkx): glycan graph as a networkx object
-  | glycan (string): glycan sequence in IUPAC-condensed
-  | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
-  | Returns:
-  | :-
-  | Returns list of matches as list of node indices"""
+def process_pattern(p: str, # Pattern description
+                   p2: Union[str, Dict[str, List[int]]], # Pattern or occurrence dict
+                   ggraph: nx.Graph, # Glycan graph
+                   glycan: str, # Glycan in IUPAC-condensed
+                   match_location: Optional[str] # Location to match: start/end/internal
+                  ) -> Union[List[List[int]], bool]: # Match node indices or False
+  "Check if and where glycomotif exists in glycan"
   return process_complex_pattern(p, p2, ggraph, glycan, match_location) if isinstance(p2, dict) else process_simple_pattern(p2, ggraph, match_location)
 
 
-def match_it_up(pattern_components: list[str], glycan: str, ggraph: nx.Graph) -> list[tuple[str, list[list[int]]]]:
-  """for a chunked glyco-regular expression, checks whether and where it can be found in glycan\n
-  | Arguments:
-  | :-
-  | pattern_components (list): list of pattern components from glyco-regular expression
-  | glycan (string): glycan sequence in IUPAC-condensed
-  | ggraph (networkx): glycan graph as a networkx object\n
-  | Returns:
-  | :-
-  | Returns list of tuples of form (pattern component, list of matches as node indices)"""
+def match_it_up(pattern_components: List[str], # Pattern chunks
+                glycan: str, # Glycan in IUPAC-condensed
+                ggraph: nx.Graph # Glycan graph
+               ) -> List[Tuple[str, List[List[int]]]]: # [(pattern, matches)]
+  "Find pattern component matches in glycan"
   pattern_matches = []
   for p in pattern_components:
     p2 = convert_pattern_component(p)
@@ -355,16 +287,11 @@ def match_it_up(pattern_components: list[str], glycan: str, ggraph: nx.Graph) ->
   return pattern_matches
 
 
-def all_combinations(nested_list: list[list[int]], min_len: int = 1, max_len: int = 2) -> list[tuple[int, ...]]:
-  """for a nested list of matches as node indices, creates possible combinations\n
-  | Arguments:
-  | :-
-  | nested_list (list): list of matches as list of node indices
-  | min_len (int): how long the combination has to be at least; default:1
-  | max_len (int): how long the combination can be at most; default:2\n
-  | Returns:
-  | :-
-  | Returns set of possible combinations of node indices for matches"""
+def all_combinations(nested_list: List[List[int]], # List of match indices
+                    min_len: int = 1, # Minimum combination length
+                    max_len: int = 2 # Maximum combination length
+                   ) -> List[Tuple[int, ...]]: # Possible index combinations
+  "Create possible combinations from nested list of matches"
   # Flatten each sublist for intra-list combinations
   if isinstance(nested_list[0][0], int):
       nested_list = [nested_list]
@@ -383,20 +310,14 @@ def all_combinations(nested_list: list[list[int]], min_len: int = 1, max_len: in
   return sorted(intra_list_combinations | inter_list_combinations)
 
 
-def try_matching(current_trace: list[int], all_match_nodes: list[list[int]], edges: list[tuple[int, int]], min_occur: int = 1, 
-                max_occur: int = 1, branch: bool = False) -> list[list[int]] | bool:
-  """tries to extend current trace to the matches of the next pattern component\n
-  | Arguments:
-  | :-
-  | current_trace (list): list of node indices of current overall match
-  | all_match_nodes (list): nested list of matches of next pattern component as lists of node indices
-  | edges (list): list of edges as tuples of connected node indices in glycan graph
-  | min_occur (int): how long the combination has to be at least; default:1
-  | max_occur (int): how long the combination can be at most; default:1
-  | branch (bool): whether next pattern component should be searched for in a different branch; default:False\n
-  | Returns:
-  | :-
-  | Returns node indices from match that can be used to extend the trace"""
+def try_matching(current_trace: List[int], # Current match indices
+                all_match_nodes: List[List[int]], # Next component matches
+                edges: List[Tuple[int, int]], # Graph edges
+                min_occur: int = 1, # Minimum occurrences; default:1
+                max_occur: int = 1, # Maximum occurrences; default:1
+                branch: bool = False # Whether to search different branch for next pattern component; default:False
+               ) -> Union[List[List[int]], bool]: # Extended trace or False
+  "Try extending current trace to next pattern matches"
   if max_occur == 0 and branch:
     return True
   if not all_match_nodes or max([len(k) for k in all_match_nodes]) < 1:
@@ -425,14 +346,9 @@ def try_matching(current_trace: list[int], all_match_nodes: list[list[int]], edg
   return sorted(matched_nodes, key = lambda x: (len(x), x[-1]))
 
 
-def parse_pattern(pattern: str) -> tuple[int, int]:
-  """extracts minimum/maximum occurrence from glyco-regular motif chunk\n
-  | Arguments:
-  | :-
-  | pattern (string): pattern component of glyco-regular motif\n
-  | Returns:
-  | :-
-  | Returns (minimum occurrence, maximum occurrence) as ints"""
+def parse_pattern(pattern: str # Pattern component from glyco-regular motif
+                ) -> Tuple[int, int]: # (Minimum occurrence, Maximum occurrence)
+  "Extract occurrence limits from glyco-regular motif pattern"
   temp = pattern.split('{')[1].split('}')[0].split(',') if '{' in pattern else None
   min_occur, max_occur = (int(temp[0]), int(temp[0])) if temp and len(temp) == 1 else \
                           (int(temp[0]) if temp[0] else 0, int(temp[1]) if temp[1] else 8) if temp else \
@@ -444,8 +360,13 @@ def parse_pattern(pattern: str) -> tuple[int, int]:
   return min_occur, max_occur
 
 
-def do_trace(start_pattern: tuple[str, list[list[int]]], idx: int, pattern_matches: list[tuple[str, list[list[int]]]], 
-             optional_components: dict[str, tuple[int, int]], edges: list[tuple[int, int]]) -> tuple[list[list[int]], list[list[str]]]:
+def do_trace(start_pattern: Tuple[str, List[List[int]]], # (Pattern, Match indices)
+            idx: int, # Current pattern index
+            pattern_matches: List[Tuple[str, List[List[int]]]], # List of (Pattern, Matches)
+            optional_components: Dict[str, Tuple[int, int]], # Pattern to min/max occurrences
+            edges: List[Tuple[int, int]] # Graph edges
+           ) -> Tuple[List[List[int]], List[List[str]]]: # (Match traces, Used patterns)
+  "Try to extend current trace through pattern component matches"
   all_traces, all_used_patterns = [], []
   for start_match in start_pattern[1]:
     if not start_match and optional_components.get(start_pattern[0], (99,99))[0] > 0:
@@ -477,16 +398,10 @@ def do_trace(start_pattern: tuple[str, list[list[int]]], idx: int, pattern_match
   return all_traces, all_used_patterns
 
 
-def trace_path(pattern_matches: list[tuple[str, list[list[int]]]], ggraph: nx.Graph) -> tuple[list[list[int]], list[list[str]]]:
-  """given all matches to all pattern components, try to connect them in one trace\n
-  | Arguments:
-  | :-
-  | pattern_matches (list): list of tuples of form (pattern component, list of matches as lists of node indices)
-  | ggraph (networkx): glycan graph as a networkx object\n
-  | Returns:
-  | :-
-  | i) nested list containing traces as lists of node indices
-  | ii) nested list containing which pattern components are present in corresponding trace, as lists"""
+def trace_path(pattern_matches: List[Tuple[str, List[List[int]]]], # [(pattern, matches)]
+              ggraph: nx.Graph # Glycan graph
+             ) -> Tuple[List[List[int]], List[List[str]]]: # (traces, used patterns)
+  "Connect pattern component matches into complete traces"
   all_traces, all_used_patterns = [], []
   patterns = [p[0] for p in pattern_matches]
   edges = list(ggraph.edges())
@@ -507,14 +422,9 @@ def trace_path(pattern_matches: list[tuple[str, list[list[int]]]], ggraph: nx.Gr
   return all_traces, all_used_patterns
 
 
-def fill_missing_in_list(lists: list[list[int]]) -> list[list[int]]:
-  """Fills in the missing integers in a list of lists to make a full range\n
-  | Arguments:
-  | :-
-  | lists (list of list of int): A list containing sublists of integers\n
-  | Returns:
-  | :-
-  | Returns a list of list of int: The input list with missing integers filled in."""
+def fill_missing_in_list(lists: List[List[int]] # Lists of indices
+                       ) -> List[List[int]]: # Lists with gaps filled
+  "Fill missing integers in lists to make full ranges"
   if lookahead_snuck_in:
     lists = [le[:-1] for le in lists]
   filled_lists = []
@@ -536,28 +446,18 @@ def fill_missing_in_list(lists: list[list[int]]) -> list[list[int]]:
   return [list(tpl) for tpl in unique_tuples]
 
 
-def format_retrieved_matches(lists: list[list[int]], ggraph: nx.Graph) -> list[str]:
-  """transforms traces into glycan strings\n
-  | Arguments:
-  | :-
-  | lists (list of list of int): A list of traces containing sublists of node indices
-  | ggraph (networkx): glycan graph as a networkx object\n
-  | Returns:
-  | :-
-  | Returns a list of glycan strings that match the glyco-regular expression"""
+def format_retrieved_matches(lists: List[List[int]], # List of traces
+                           ggraph: nx.Graph # Glycan graph
+                          ) -> List[str]: # Matching glycan strings
+  "Convert traces into glycan strings"
   return sorted([graph_to_string(ggraph.subgraph(trace)) for trace in lists if nx.is_connected(ggraph.subgraph(trace))], key = len, reverse = True)
 
 
-def filter_dealbreakers(lists: list[list[int]], ggraph: nx.Graph, pattern: str) -> list[list[int]]:
-  """performs some checks to see whether traces come from sequences breaking the pattern negations\n
-  | Arguments:
-  | :-
-  | lists (list of list of int): A list of traces containing sublists of node indices
-  | ggraph (networkx): glycan graph as a networkx object
-  | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
-  | Returns:
-  | :-
-  | Returns a list of list of int; basically traces that survive the filtering"""
+def filter_dealbreakers(lists: List[List[int]], # List of traces
+                       ggraph: nx.Graph, # Glycan graph
+                       pattern: str # Glyco-regular expression, e.g., "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"
+                      ) -> List[List[int]]: # Filtered traces
+  "Filter traces breaking pattern negations"
   if '!' not in pattern:
     return lists
   else:
@@ -579,28 +479,18 @@ def filter_dealbreakers(lists: list[list[int]], ggraph: nx.Graph, pattern: str) 
     return lists2
 
 
-def compile_pattern(pattern: str) -> list[str]:
-  """pre-compiles glyco-regular expression for faster processing\n
-  | Arguments:
-  | :-
-  | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
-  | Returns:
-  | :-
-  | Returns a list of pattern components"""
+def compile_pattern(pattern: str # Glyco-regular expression, e.g., "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"
+                  ) -> List[str]: # Pre-compiled pattern chunks
+  "Pre-compile glyco-regular expression for faster processing"
   pattern = pattern[1:] if pattern.startswith('r') else pattern
   return preprocess_pattern(pattern)
 
 
-def get_match(pattern: str | list[str], glycan: str | nx.Graph, return_matches: bool = True) -> bool | list[str]:
-  """finds matches for a glyco-regular expression in a glycan\n
-  | Arguments:
-  | :-
-  | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"; accepts pre-compiled pattern
-  | glycan (string or networkx): glycan sequence in IUPAC-condensed or as networkx graph
-  | return_matches (bool): whether to return True/False or return the matches as a list of strings; default:True\n
-  | Returns:
-  | :-
-  | Returns either a boolean (return_matches = False) or a list of matches as strings (return_matches = True)"""
+def get_match(pattern: Union[str, List[str]], # Expression or pre-compiled pattern; e.g., "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"
+              glycan: Union[str, nx.Graph], # Glycan string or graph
+              return_matches: bool = True # Whether to return matches vs boolean
+             ) -> Union[bool, List[str]]: # Match results
+  "Find matches for glyco-regular expression in glycan"
   pattern = pattern[1:] if pattern.startswith('r') else pattern
   global lookahead_snuck_in
   lookahead_snuck_in = False
@@ -624,21 +514,18 @@ def get_match(pattern: str | list[str], glycan: str | nx.Graph, return_matches: 
   return False if not return_matches else []
 
 
-def get_match_batch(pattern: str, glycan_list: list[str | nx.Graph], return_matches: bool = True) -> list[bool] | list[list[str]]:
-  """finds matches for a glyco-regular expression in a list of glycans\n
-  | Arguments:
-  | :-
-  | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"; accepts pre-compiled pattern
-  | glycan_list (list of strings or networkx): list of glycan sequence in IUPAC-condensed or as networkx graph
-  | return_matches (bool): whether to return True/False or return the matches as a list of strings; default:True\n
-  | Returns:
-  | :-
-  | Returns either a list of booleans (return_matches = False) or a list of list of matches as strings (return_matches = True)"""
+def get_match_batch(pattern: str, # Glyco-regular expression; e.g., "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"
+                   glycan_list: List[Union[str, nx.Graph]], # List of glycans
+                   return_matches: bool = True # Whether to return matches vs boolean
+                  ) -> Union[List[bool], List[List[str]]]: # Match results for each glycan
+  "Find glyco-regular expression matches in list of glycans"
   pattern = compile_pattern(pattern)
   return [get_match(pattern, g, return_matches = return_matches) for g in glycan_list]
 
 
-def reformat_glycan_string(glycan: str) -> str:
+def reformat_glycan_string(glycan: str # Glycan in IUPAC-condensed
+                         ) -> str: # Reformatted pattern string
+  "Convert glycan string to pattern format"
   # Contract linkages
   glycan = re.sub(r"\((\w)(\d+)-(\d+)\)", r"\1\3-", glycan)
   glycan = re.sub(r"\((\w)(\d+)-(\?)\)", r"\1?-", glycan)  # Handle cases with '?'
@@ -648,14 +535,9 @@ def reformat_glycan_string(glycan: str) -> str:
   return glycan.strip('-')
 
 
-def motif_to_regex(motif: str) -> str:
-  """tries to convert motif into a regular expression\n
-  | Arguments:
-  | :-
-  | motif (string): glycan in IUPAC-condensed nomenclature\n
-  | Returns:
-  | :-
-  | Returns regular expression if successful"""
+def motif_to_regex(motif: str # Glycan in IUPAC-condensed
+                  ) -> str: # Regular expression
+  "Convert glycan motif to regular expression pattern"
   motif = canonicalize_iupac(motif)
   pattern = reformat_glycan_string(motif)
   if not get_match(pattern, motif, return_matches = False):

--- a/glycowork/motif/regex.py
+++ b/glycowork/motif/regex.py
@@ -7,15 +7,14 @@ from glycowork.motif.processing import min_process_glycans, bracket_removal, can
 from glycowork.motif.graph import graph_to_string, subgraph_isomorphism, compare_glycans, glycan_to_nxGraph
 
 
-def preprocess_pattern(pattern):
+def preprocess_pattern(pattern: str) -> list[str]:
   """transforms a glyco-regular expression into chunks\n
   | Arguments:
   | :-
   | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
   | Returns:
   | :-
-  | Returns list of chunks to be used by downstream functions
-  """
+  | Returns list of chunks to be used by downstream functions"""
   # Use regular expression to identify the conditional parts and keep other chunks together
   pattern = pattern.replace('.', 'Monosaccharide')
   components = re.split(r'(-?\s*\(?\[.*?\]\)?\s*(?:\{,?\d*,?\d*\}\?|\{,?\d*,?\d*\}|\*\?|\+\?|\?|\*|\+)\s*-?)', pattern)
@@ -23,15 +22,14 @@ def preprocess_pattern(pattern):
   return [x.strip('-').strip() for x in components if x]
 
 
-def specify_linkages(pattern_component):
+def specify_linkages(pattern_component: str) -> str:
   """allows for specification of exact linkages by converting expressions such as Mana6 to Man(a1-6)\n
   | Arguments:
   | :-
   | pattern_component (string): chunk of a glyco-regular expression\n
   | Returns:
   | :-
-  | Returns specified chunk to be used by downstream functions
-  """
+  | Returns specified chunk to be used by downstream functions"""
   if re.search(r"[\d|\?]\(|\d$", pattern_component):
     pattern = re.compile(r"([ab\?])([2-9\?])\(\?1-\?\)")
     def replacer(match):
@@ -41,26 +39,25 @@ def specify_linkages(pattern_component):
   return pattern_component.replace('5Ac(a1', '5Ac(a2').replace('5Gc(a1', '5Gc(a2').replace('Kdn(a1', 'Kdn(a2').replace('Sia(a1', 'Sia(a2')
 
 
-def replace_patterns(s):
+def replace_patterns(s: str) -> str:
   return s.replace('-', '(?1-?)').replace('5Ac(?1', '5Ac(?2').replace('5Gc(?1', '5Gc(?2')
 
 
-def process_occurrence(occ_str):
+def process_occurrence(occ_str: str) -> list[int]:
   """processes the minimum and maximum occurrence of a pattern component\n
   | Arguments:
   | :-
   | occ_str (string): content between {} of a pattern component\n
   | Returns:
   | :-
-  | Returns list of minimum and maximum occurrence
-  """
+  | Returns list of minimum and maximum occurrence"""
   occ = occ_str.split(',')
   if len(occ) == 1:
     return [int(occ[0]), int(occ[0])]
   return [int(occ[0]) if occ[0] else 0, int(occ[1]) if occ[1] else 5]
 
 
-def process_question_mark(s, p):
+def process_question_mark(s: str, p: str) -> tuple[list[int], list[str]]:
   """processes pattern components with lookahead/-behind or just regular ? characters\n
   | Arguments:
   | :-
@@ -68,8 +65,7 @@ def process_question_mark(s, p):
   | p (string): content between [] in pattern component\n
   | Returns:
   | :-
-  | Returns list of minimum and maximum occurrence + cleaned up pattern component
-  """
+  | Returns list of minimum and maximum occurrence + cleaned up pattern component"""
   if '?<' in s:
     occurrence = [1]
     part = s.split('=')[1].replace(')', '') if '=' in s else s.split(')')[1]
@@ -83,15 +79,14 @@ def process_question_mark(s, p):
   return occurrence, pattern
 
 
-def expand_pattern(pattern_component):
+def expand_pattern(pattern_component: str) -> list[str]:
   """allows for specification of ambiguous (but not wildcarded) linkages by converting expressions such as Galb3/4 to the two specified versions\n
   | Arguments:
   | :-
   | pattern_component (string): chunk of a glyco-regular expression\n
   | Returns:
   | :-
-  | Returns a list of specified pattern components, ready for specify_linkages etc.
-  """
+  | Returns a list of specified pattern components, ready for specify_linkages etc."""
   # Find the window of ambiguity (a segment with characters separated by slashes)
   match = re.findall(r'\d\/\d', pattern_component)
   if not match:
@@ -103,15 +98,14 @@ def expand_pattern(pattern_component):
   return [pattern_component.replace(ambiguous_window, char, 1) for char in ambiguous_chars]
 
 
-def convert_pattern_component(pattern_component):
+def convert_pattern_component(pattern_component: str) -> str | dict[str, list[int]]:
   """processes a pattern component into either a string or dict of form string : occurrence\n
   | Arguments:
   | :-
   | pattern_component (string): chunk of a glyco-regular expression\n
   | Returns:
   | :-
-  | Returns a string for simple components and a dict of form string : occurrence for complex components
-  """
+  | Returns a string for simple components and a dict of form string : occurrence for complex components"""
   if not any([k in pattern_component for k in ['[', '{', '*', '+', '=', '<!', '?!']]):
     if pattern_component[-1].isdigit() or pattern_component[-1] == '?':
       pattern_component += '-'
@@ -142,7 +136,7 @@ def convert_pattern_component(pattern_component):
   return {specify_linkages(p): occurrence for p in pattern}
 
 
-def process_main_branch(glycan, glycan_parts):
+def process_main_branch(glycan: str, glycan_parts: list[str]) -> list[str]:
   """extracts the main chain node indices of a glycan\n
   | Arguments:
   | :-
@@ -150,8 +144,7 @@ def process_main_branch(glycan, glycan_parts):
   | glycan_parts (list): list of glycoletters as returned by min_process_glycans\n
   | Returns:
   | :-
-  | Returns a list of node indices, in which node indices not belonging to the main chain have been replaced by empty strings
-  """
+  | Returns a list of node indices, in which node indices not belonging to the main chain have been replaced by empty strings"""
   glycan_dic = {i:p for i,p in enumerate(glycan_parts)}
   glycan2 = bracket_removal(glycan)
   glycan_parts2 = min_process_glycans([glycan2])[0]
@@ -167,7 +160,7 @@ def process_main_branch(glycan, glycan_parts):
   return list(glycan_dic.values())
 
 
-def check_negative_look(matches, pattern, glycan):
+def check_negative_look(matches: list[list[int]], pattern: str, glycan: str) -> list[list[int]]:
   """filters the matches by whether they fulfill the negative lookahead/-behind condition\n
   | Arguments:
   | :-
@@ -176,8 +169,7 @@ def check_negative_look(matches, pattern, glycan):
   | glycan (string): glycan sequence in IUPAC-condensed\n
   | Returns:
   | :-
-  | Returns a filtered list of matches
-  """
+  | Returns a filtered list of matches"""
   glycan_parts = min_process_glycans([glycan])[0]
   glycan_parts_main = process_main_branch(glycan, glycan_parts)
   part = convert_pattern_component(pattern.split('!')[1].split(')')[0])
@@ -204,7 +196,7 @@ def check_negative_look(matches, pattern, glycan):
   return [m for i, m in enumerate(matches) if not compare_glycans(target_locs[i], part)]
 
 
-def filter_matches_by_location(matches, ggraph, match_location):
+def filter_matches_by_location(matches: list[list[int]], ggraph: nx.Graph, match_location: str | None) -> list[list[int]]:
   """filters the matches by whether they fulfill the location condition (start/end)\n
   | Arguments:
   | :-
@@ -213,8 +205,7 @@ def filter_matches_by_location(matches, ggraph, match_location):
   | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
   | Returns:
   | :-
-  | Returns a filtered list of matches
-  """
+  | Returns a filtered list of matches"""
   if matches and matches[0] and matches[0][0] and isinstance(matches[0][0], list):
     matches = unwrap(matches)
   if match_location == 'start':
@@ -228,7 +219,7 @@ def filter_matches_by_location(matches, ggraph, match_location):
   return matches
 
 
-def process_simple_pattern(p2, ggraph, match_location):
+def process_simple_pattern(p2: nx.Graph, ggraph: nx.Graph, match_location: str | None) -> list[list[int]] | bool:
   """for just a straight-up glycomotif, checks whether and where it can be found in glycan\n
   | Arguments:
   | :-
@@ -237,8 +228,7 @@ def process_simple_pattern(p2, ggraph, match_location):
   | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
   | Returns:
   | :-
-  | Returns list of matches as list of node indices
-  """
+  | Returns list of matches as list of node indices"""
   res = subgraph_isomorphism(ggraph, p2, return_matches = True)
   if not res:
     return False
@@ -252,15 +242,14 @@ def process_simple_pattern(p2, ggraph, match_location):
   return [m for m in matches if all(x < y for x, y in zip(m, m[1:]))]
 
 
-def calculate_len_matches_comb(len_matches):
+def calculate_len_matches_comb(len_matches: list[list[int]]) -> list[int]:
   """takes a list of lengths of the matched sequences, returns a list of lengths considering the combination of the matches\n
   | Arguments:
   | :-
   | len_matches (list): list of match lengths\n
   | Returns:
   | :-
-  | Returns list of lengths of possible combinations of matches
-  """
+  | Returns list of lengths of possible combinations of matches"""
   if not len_matches:
     return [0]
   if len(len_matches) == 1:
@@ -272,7 +261,8 @@ def calculate_len_matches_comb(len_matches):
     return list(set(unwrap(len_matches) + [sum(combination) for combination in cartesian_product]))
 
 
-def process_complex_pattern(p, p2, ggraph, glycan, match_location):
+def process_complex_pattern(p: str, p2: dict[str, list[int]], ggraph: nx.Graph,
+                          glycan: str, match_location: str | None) -> list[list[int]] | bool:
   """for a glycomotif with regular expression modifiers, checks whether and where it can be found in glycan\n
   | Arguments:
   | :-
@@ -283,8 +273,7 @@ def process_complex_pattern(p, p2, ggraph, glycan, match_location):
   | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
   | Returns:
   | :-
-  | Returns list of matches as list of node indices
-  """
+  | Returns list of matches as list of node indices"""
   if not any('-' in p_key for p_key in p2.keys()):
     p2_keys = [specify_linkages(replace_patterns(p_key + '-' if p_key[-1].isdigit() or p_key[-1] == '?' else p_key)) for p_key in p2.keys()]
   else:
@@ -326,7 +315,7 @@ def process_complex_pattern(p, p2, ggraph, glycan, match_location):
   return matches
 
 
-def process_pattern(p, p2, ggraph, glycan, match_location):
+def process_pattern(p: str, p2: str | dict[str, list[int]], ggraph: nx.Graph, glycan: str, match_location: str | None) -> list[list[int]] | bool:
   """for a glycomotif, checks whether and where it can be found in glycan\n
   | Arguments:
   | :-
@@ -337,12 +326,11 @@ def process_pattern(p, p2, ggraph, glycan, match_location):
   | match_location (string): whether the match should have been at the "start", "end", or "internal" of the sequence\n
   | Returns:
   | :-
-  | Returns list of matches as list of node indices
-  """
+  | Returns list of matches as list of node indices"""
   return process_complex_pattern(p, p2, ggraph, glycan, match_location) if isinstance(p2, dict) else process_simple_pattern(p2, ggraph, match_location)
 
 
-def match_it_up(pattern_components, glycan, ggraph):
+def match_it_up(pattern_components: list[str], glycan: str, ggraph: nx.Graph) -> list[tuple[str, list[list[int]]]]:
   """for a chunked glyco-regular expression, checks whether and where it can be found in glycan\n
   | Arguments:
   | :-
@@ -351,8 +339,7 @@ def match_it_up(pattern_components, glycan, ggraph):
   | ggraph (networkx): glycan graph as a networkx object\n
   | Returns:
   | :-
-  | Returns list of tuples of form (pattern component, list of matches as node indices)
-  """
+  | Returns list of tuples of form (pattern component, list of matches as node indices)"""
   pattern_matches = []
   for p in pattern_components:
     p2 = convert_pattern_component(p)
@@ -368,7 +355,7 @@ def match_it_up(pattern_components, glycan, ggraph):
   return pattern_matches
 
 
-def all_combinations(nested_list, min_len = 1, max_len = 2):
+def all_combinations(nested_list: list[list[int]], min_len: int = 1, max_len: int = 2) -> list[tuple[int, ...]]:
   """for a nested list of matches as node indices, creates possible combinations\n
   | Arguments:
   | :-
@@ -377,8 +364,7 @@ def all_combinations(nested_list, min_len = 1, max_len = 2):
   | max_len (int): how long the combination can be at most; default:2\n
   | Returns:
   | :-
-  | Returns set of possible combinations of node indices for matches
-  """
+  | Returns set of possible combinations of node indices for matches"""
   # Flatten each sublist for intra-list combinations
   if isinstance(nested_list[0][0], int):
       nested_list = [nested_list]
@@ -397,7 +383,8 @@ def all_combinations(nested_list, min_len = 1, max_len = 2):
   return sorted(intra_list_combinations | inter_list_combinations)
 
 
-def try_matching(current_trace, all_match_nodes, edges, min_occur = 1, max_occur = 1, branch = False):
+def try_matching(current_trace: list[int], all_match_nodes: list[list[int]], edges: list[tuple[int, int]], min_occur: int = 1, 
+                max_occur: int = 1, branch: bool = False) -> list[list[int]] | bool:
   """tries to extend current trace to the matches of the next pattern component\n
   | Arguments:
   | :-
@@ -409,8 +396,7 @@ def try_matching(current_trace, all_match_nodes, edges, min_occur = 1, max_occur
   | branch (bool): whether next pattern component should be searched for in a different branch; default:False\n
   | Returns:
   | :-
-  | Returns node indices from match that can be used to extend the trace
-  """
+  | Returns node indices from match that can be used to extend the trace"""
   if max_occur == 0 and branch:
     return True
   if not all_match_nodes or max([len(k) for k in all_match_nodes]) < 1:
@@ -439,15 +425,14 @@ def try_matching(current_trace, all_match_nodes, edges, min_occur = 1, max_occur
   return sorted(matched_nodes, key = lambda x: (len(x), x[-1]))
 
 
-def parse_pattern(pattern):
+def parse_pattern(pattern: str) -> tuple[int, int]:
   """extracts minimum/maximum occurrence from glyco-regular motif chunk\n
   | Arguments:
   | :-
   | pattern (string): pattern component of glyco-regular motif\n
   | Returns:
   | :-
-  | Returns (minimum occurrence, maximum occurrence) as ints
-  """
+  | Returns (minimum occurrence, maximum occurrence) as ints"""
   temp = pattern.split('{')[1].split('}')[0].split(',') if '{' in pattern else None
   min_occur, max_occur = (int(temp[0]), int(temp[0])) if temp and len(temp) == 1 else \
                           (int(temp[0]) if temp[0] else 0, int(temp[1]) if temp[1] else 8) if temp else \
@@ -459,7 +444,8 @@ def parse_pattern(pattern):
   return min_occur, max_occur
 
 
-def do_trace(start_pattern, idx, pattern_matches, optional_components, edges):
+def do_trace(start_pattern: tuple[str, list[list[int]]], idx: int, pattern_matches: list[tuple[str, list[list[int]]]], 
+             optional_components: dict[str, tuple[int, int]], edges: list[tuple[int, int]]) -> tuple[list[list[int]], list[list[str]]]:
   all_traces, all_used_patterns = [], []
   for start_match in start_pattern[1]:
     if not start_match and optional_components.get(start_pattern[0], (99,99))[0] > 0:
@@ -491,7 +477,7 @@ def do_trace(start_pattern, idx, pattern_matches, optional_components, edges):
   return all_traces, all_used_patterns
 
 
-def trace_path(pattern_matches, ggraph):
+def trace_path(pattern_matches: list[tuple[str, list[list[int]]]], ggraph: nx.Graph) -> tuple[list[list[int]], list[list[str]]]:
   """given all matches to all pattern components, try to connect them in one trace\n
   | Arguments:
   | :-
@@ -500,8 +486,7 @@ def trace_path(pattern_matches, ggraph):
   | Returns:
   | :-
   | i) nested list containing traces as lists of node indices
-  | ii) nested list containing which pattern components are present in corresponding trace, as lists
-  """
+  | ii) nested list containing which pattern components are present in corresponding trace, as lists"""
   all_traces, all_used_patterns = [], []
   patterns = [p[0] for p in pattern_matches]
   edges = list(ggraph.edges())
@@ -522,15 +507,14 @@ def trace_path(pattern_matches, ggraph):
   return all_traces, all_used_patterns
 
 
-def fill_missing_in_list(lists):
+def fill_missing_in_list(lists: list[list[int]]) -> list[list[int]]:
   """Fills in the missing integers in a list of lists to make a full range\n
   | Arguments:
   | :-
   | lists (list of list of int): A list containing sublists of integers\n
   | Returns:
   | :-
-  | Returns a list of list of int: The input list with missing integers filled in.
-  """
+  | Returns a list of list of int: The input list with missing integers filled in."""
   if lookahead_snuck_in:
     lists = [le[:-1] for le in lists]
   filled_lists = []
@@ -552,7 +536,7 @@ def fill_missing_in_list(lists):
   return [list(tpl) for tpl in unique_tuples]
 
 
-def format_retrieved_matches(lists, ggraph):
+def format_retrieved_matches(lists: list[list[int]], ggraph: nx.Graph) -> list[str]:
   """transforms traces into glycan strings\n
   | Arguments:
   | :-
@@ -560,12 +544,11 @@ def format_retrieved_matches(lists, ggraph):
   | ggraph (networkx): glycan graph as a networkx object\n
   | Returns:
   | :-
-  | Returns a list of glycan strings that match the glyco-regular expression
-  """
+  | Returns a list of glycan strings that match the glyco-regular expression"""
   return sorted([graph_to_string(ggraph.subgraph(trace)) for trace in lists if nx.is_connected(ggraph.subgraph(trace))], key = len, reverse = True)
 
 
-def filter_dealbreakers(lists, ggraph, pattern):
+def filter_dealbreakers(lists: list[list[int]], ggraph: nx.Graph, pattern: str) -> list[list[int]]:
   """performs some checks to see whether traces come from sequences breaking the pattern negations\n
   | Arguments:
   | :-
@@ -574,8 +557,7 @@ def filter_dealbreakers(lists, ggraph, pattern):
   | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
   | Returns:
   | :-
-  | Returns a list of list of int; basically traces that survive the filtering
-  """
+  | Returns a list of list of int; basically traces that survive the filtering"""
   if '!' not in pattern:
     return lists
   else:
@@ -597,20 +579,19 @@ def filter_dealbreakers(lists, ggraph, pattern):
     return lists2
 
 
-def compile_pattern(pattern):
+def compile_pattern(pattern: str) -> list[str]:
   """pre-compiles glyco-regular expression for faster processing\n
   | Arguments:
   | :-
   | pattern (string): glyco-regular expression in the form of "Hex-HexNAc-([Hex|Fuc]){1,2}-HexNAc"\n
   | Returns:
   | :-
-  | Returns a list of pattern components
-  """
+  | Returns a list of pattern components"""
   pattern = pattern[1:] if pattern.startswith('r') else pattern
   return preprocess_pattern(pattern)
 
 
-def get_match(pattern, glycan, return_matches = True):
+def get_match(pattern: str | list[str], glycan: str | nx.Graph, return_matches: bool = True) -> bool | list[str]:
   """finds matches for a glyco-regular expression in a glycan\n
   | Arguments:
   | :-
@@ -619,8 +600,7 @@ def get_match(pattern, glycan, return_matches = True):
   | return_matches (bool): whether to return True/False or return the matches as a list of strings; default:True\n
   | Returns:
   | :-
-  | Returns either a boolean (return_matches = False) or a list of matches as strings (return_matches = True)
-  """
+  | Returns either a boolean (return_matches = False) or a list of matches as strings (return_matches = True)"""
   pattern = pattern[1:] if pattern.startswith('r') else pattern
   global lookahead_snuck_in
   lookahead_snuck_in = False
@@ -644,7 +624,7 @@ def get_match(pattern, glycan, return_matches = True):
   return False if not return_matches else []
 
 
-def get_match_batch(pattern, glycan_list, return_matches = True):
+def get_match_batch(pattern: str, glycan_list: list[str | nx.Graph], return_matches: bool = True) -> list[bool] | list[list[str]]:
   """finds matches for a glyco-regular expression in a list of glycans\n
   | Arguments:
   | :-
@@ -653,13 +633,12 @@ def get_match_batch(pattern, glycan_list, return_matches = True):
   | return_matches (bool): whether to return True/False or return the matches as a list of strings; default:True\n
   | Returns:
   | :-
-  | Returns either a list of booleans (return_matches = False) or a list of list of matches as strings (return_matches = True)
-  """
+  | Returns either a list of booleans (return_matches = False) or a list of list of matches as strings (return_matches = True)"""
   pattern = compile_pattern(pattern)
   return [get_match(pattern, g, return_matches = return_matches) for g in glycan_list]
 
 
-def reformat_glycan_string(glycan):
+def reformat_glycan_string(glycan: str) -> str:
   # Contract linkages
   glycan = re.sub(r"\((\w)(\d+)-(\d+)\)", r"\1\3-", glycan)
   glycan = re.sub(r"\((\w)(\d+)-(\?)\)", r"\1?-", glycan)  # Handle cases with '?'
@@ -669,15 +648,14 @@ def reformat_glycan_string(glycan):
   return glycan.strip('-')
 
 
-def motif_to_regex(motif):
+def motif_to_regex(motif: str) -> str:
   """tries to convert motif into a regular expression\n
   | Arguments:
   | :-
   | motif (string): glycan in IUPAC-condensed nomenclature\n
   | Returns:
   | :-
-  | Returns regular expression if successful
-  """
+  | Returns regular expression if successful"""
   motif = canonicalize_iupac(motif)
   pattern = reformat_glycan_string(motif)
   if not get_match(pattern, motif, return_matches = False):

--- a/glycowork/motif/tokenization.py
+++ b/glycowork/motif/tokenization.py
@@ -6,6 +6,7 @@ import copy
 from importlib import resources
 from collections import Counter
 from sklearn.cluster import DBSCAN
+from typing import Dict, List, Set, Union, Optional, Tuple
 
 from glycowork.glycan_data.loader import lib, unwrap, df_glycan, Hex, dHex, HexA, HexN, HexNAc, Pen, linkages
 from glycowork.motif.processing import min_process_glycans, rescue_glycans, rescue_compositions
@@ -20,15 +21,10 @@ with resources.open_text("glycowork.motif", "mz_to_composition.csv") as f:
 mass_dict = dict(zip(mapping_file.composition, mapping_file["underivatized_monoisotopic"]))
 
 
-def constrain_prot(proteins: list[str], libr: dict[str, int] | None = None) -> list[str]:
-  """Ensures that no characters outside of libr are present in proteins\n
-  | Arguments:
-  | :-
-  | proteins (list): list of proteins as strings
-  | libr (list): sorted list of amino acids occurring in proteins\n
-  | Returns:
-  | :-
-  | Returns list of proteins with only permitted amino acids"""
+def constrain_prot(proteins: List[str], # List of protein sequences
+                  libr: Optional[Dict[str, int]] = None # Dictionary mapping amino acids to indices
+                 ) -> List[str]: # List of filtered protein sequences
+  "Ensure only characters from library are present in proteins"
   if libr is None:
     libr = chars
   # Check whether any character is not in libr and replace it with a 'z' placeholder character
@@ -36,16 +32,11 @@ def constrain_prot(proteins: list[str], libr: dict[str, int] | None = None) -> l
   return [''.join(c if c in libr_set else 'z' for c in protein) for protein in proteins]
 
 
-def prot_to_coded(proteins: list[str], libr: dict[str, int] | None = None, pad_len: int = 1000) -> list[list[int]]:
-  """Encodes protein sequences to be used in LectinOracle-flex\n
-  | Arguments:
-  | :-
-  | proteins (list): list of proteins as strings
-  | libr (list): sorted list of amino acids occurring in proteins
-  | pad_len (int): length up to which the proteins are padded\n
-  | Returns:
-  | :-
-  | Returns list of encoded proteins with only permitted amino acids"""
+def prot_to_coded(proteins: List[str], # List of protein sequences
+                  libr: Optional[Dict[str, int]] = None, # Dictionary mapping amino acids to indices
+                  pad_len: int = 1000 # Length for padding sequences
+                 ) -> List[List[int]]: # List of encoded protein sequences
+  "Encode protein sequences for LectinOracle-flex"
   if libr is None:
     libr = chars
   pad_label = len(libr) - 1
@@ -59,31 +50,21 @@ def prot_to_coded(proteins: list[str], libr: dict[str, int] | None = None, pad_l
   return encoded_prots
 
 
-def string_to_labels(character_string: str, libr: dict[str, int] | None = None) -> list[int]:
-  """tokenizes word by indexing characters in passed library\n
-  | Arguments:
-  | :-
-  | character_string (string): string of characters to index
-  | libr (dict): dict of library items\n
-  | Returns:
-  | :-
-  | Returns indexes of characters in library"""
+def string_to_labels(character_string: str, # String to tokenize
+                    libr: Optional[Dict[str, int]] = None # Dictionary mapping characters to indices
+                   ) -> List[int]: # List of character indices
+  "Tokenize word by indexing characters in library"
   if libr is None:
     libr = chars
   return list(map(libr.get, character_string))
 
 
-def pad_sequence(seq: list[int], max_length: int, pad_label: int | None = None, libr: dict[str, int] | None = None) -> list[int]:
-  """brings all sequences to same length by adding padding token\n
-  | Arguments:
-  | :-
-  | seq (list): sequence to pad (from string_to_labels)
-  | max_length (int): sequence length to pad to
-  | pad_label (int): which padding label to use
-  | libr (list): list of library items\n
-  | Returns:
-  | :-
-  | Returns padded sequence"""
+def pad_sequence(seq: List[int], # Sequence to pad
+                max_length: int, # Target length
+                pad_label: Optional[int] = None, # Padding token value
+                libr: Optional[Dict[str, int]] = None # Character library
+               ) -> List[int]: # Padded sequence
+  "Pad sequences to same length using padding token"
   if libr is None:
     libr = chars
   if pad_label is None:
@@ -94,14 +75,9 @@ def pad_sequence(seq: list[int], max_length: int, pad_label: int | None = None, 
   return seq
 
 
-def get_core(sugar: str) -> str:
-  """retrieves core monosaccharide from modified monosaccharide\n
-  | Arguments:
-  | :-
-  | sugar (string): monosaccharide or linkage\n
-  | Returns:
-  | :-
-  | Returns core monosaccharide as string"""
+def get_core(sugar: str # Monosaccharide or linkage
+           ) -> str: # Core monosaccharide string
+  "Retrieve core monosaccharide from modified monosaccharide"
   easy_cores = set(['dHexNAc', 'GlcNAc', 'GalNAc', 'ManNAc', 'FucNAc', 'QuiNAc', 'RhaNAc', 'GulNAc',
                 'IdoNAc', 'Ins', 'MurNAc', '6dAltNAc', 'AcoNAc', 'HexA', 'GlcA', 'AltA',
                 'GalA', 'ManA', 'Tyv', 'Yer', 'Abe', 'GlcfNAc', 'GalfNAc', 'ManfNAc',
@@ -132,43 +108,28 @@ def get_core(sugar: str) -> str:
   return 'Monosaccharide'
 
 
-def get_modification(sugar: str) -> str:
-  """retrieves modification from modified monosaccharide\n
-  | Arguments:
-  | :-
-  | sugar (string): monosaccharide or linkage\n
-  | Returns:
-  | :-
-  | Returns modification as string"""
+def get_modification(sugar: str # Monosaccharide or linkage
+                   ) -> str: # Modification string
+  "Retrieve modification from modified monosaccharide"
   core = get_core(sugar)
   modification = sugar.replace(core, '')
   return modification
 
 
-def get_stem_lib(libr: dict[str, int]) -> dict[str, str]:
-  """creates a mapping file to map modified monosaccharides to core monosaccharides\n
-  | Arguments:
-  | :-
-  | libr (dict): dictionary of form glycoletter:index\n
-  | Returns:
-  | :-
-  | Returns dictionary of form modified_monosaccharide:core_monosaccharide"""
+def get_stem_lib(libr: Dict[str, int] # Dictionary mapping glycoletters to indices
+                ) -> Dict[str, str]: # Dictionary mapping modified to core monosaccharides
+  "Create mapping from modified monosaccharides to core monosaccharides"
   return {k: get_core(k) for k in libr}
 
 
 stem_lib = get_stem_lib(lib)
 
 
-def stemify_glycan(glycan: str, stem_lib: dict[str, str] | None = None, libr: dict[str, int] | None = None) -> str:
-  """removes modifications from all monosaccharides in a glycan\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | stem_lib (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide; default:created from lib
-  | libr (dict): dictionary of form glycoletter:index; default:lib\n
-  | Returns:
-  | :-
-  | Returns stemmed glycan as string"""
+def stemify_glycan(glycan: str, # Glycan in IUPAC-condensed format
+                  stem_lib: Optional[Dict[str, str]] = None, # Modified to core monosaccharide mapping; default:created from lib
+                  libr: Optional[Dict[str, int]] = None # Glycoletter to index mapping
+                 ) -> str: # Stemmed glycan string
+  "Remove modifications from all monosaccharides in glycan"
   if libr is None:
     libr = lib
   if stem_lib is None:
@@ -216,19 +177,13 @@ def stemify_glycan(glycan: str, stem_lib: dict[str, str] | None = None, libr: di
   return glycan
 
 
-def stemify_dataset(df: pd.DataFrame, stem_lib: dict[str, str] | None = None, libr: dict[str, int] | None = None,
-                    glycan_col_name: str = 'glycan', rarity_filter: int = 1) -> pd.DataFrame:
-  """stemifies all glycans in a dataset by removing monosaccharide modifications\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycans in IUPAC-condensed format in column glycan_col_name
-  | stem_lib (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide; default:created from lib
-  | libr (dict): dictionary of form glycoletter:index; default:lib
-  | glycan_col_name (string): column name under which glycans are stored; default:glycan
-  | rarity_filter (int): how often monosaccharide modification has to occur to not get removed; default:1\n
-  | Returns:
-  | :-
-  | Returns df with glycans stemified"""
+def stemify_dataset(df: pd.DataFrame, # DataFrame with glycan column
+                   stem_lib: Optional[Dict[str, str]] = None, # Modified to core monosaccharide mapping; default:created from lib
+                   libr: Optional[Dict[str, int]] = None, # Glycoletter to index mapping
+                   glycan_col_name: str = 'glycan', # Column name for glycans
+                   rarity_filter: int = 1 # Minimum occurrences to keep modification
+                  ) -> pd.DataFrame: # DataFrame with stemified glycans
+  "Remove monosaccharide modifications from all glycans in dataset"
   if libr is None:
     libr = lib
   if stem_lib is None:
@@ -243,28 +198,20 @@ def stemify_dataset(df: pd.DataFrame, stem_lib: dict[str, str] | None = None, li
   return df_out
 
 
-def mz_to_composition(mz_value: float, mode: str = 'negative', mass_value: str = 'monoisotopic', reduced: bool = False,
-                      sample_prep: str = 'underivatized', mass_tolerance: float = 0.5, kingdom: str = 'Animalia',
-                      glycan_class: str = 'all', df_use: pd.DataFrame | None = None, filter_out: set[str] | None = None,
-                      extras: list[str] = ["doubly_charged"], adduct: str | None = None) -> list[dict[str, int]]:
-  """Mapping a m/z value to a matching monosaccharide composition within SugarBase\n
-  | Arguments:
-  | :-
-  | mz_value (float): the actual m/z value from mass spectrometry
-  | mode (string): whether mz_value comes from MS in 'positive' or 'negative' mode; default:'negative'
-  | mass_value (string): whether the expected mass is 'monoisotopic' or 'average'; default:'monoisotopic'
-  | reduced (bool): whether glycans are reduced at reducing end; default:False
-  | sample_prep (string): whether the glycans has been 'underivatized', 'permethylated', or 'peracetylated'; default:'underivatized'
-  | mass_tolerance (float): how much deviation to tolerate for a match; default:0.5
-  | kingdom (string): taxonomic kingdom for choosing a subset of glycans to consider; default:'Animalia'
-  | glycan_class (string): which glycan class does the m/z value stem from, 'N', 'O', 'lipid' linked glycans, or 'free' glycans; default:'all'
-  | df_use (dataframe): species-specific glycan dataframe to use for mapping; default: df_glycan
-  | filter_out (set): set of monosaccharide types to ignore during composition finding; default:None
-  | extras (list): additional operations to perform if regular m/z matching does not yield a result; options include "adduct" and "doubly_charged"
-  | adduct (string): chemical formula of adduct that contributes to m/z, e.g., "C2H4O2"; default:None\n
-  | Returns:
-  | :-
-  | Returns a list of matching compositions in dict form"""
+def mz_to_composition(mz_value: float, # m/z value from mass spec
+                     mode: str = 'negative', # MS mode: positive/negative
+                     mass_value: str = 'monoisotopic', # Mass type: monoisotopic/average
+                     reduced: bool = False, # Whether glycans are reduced
+                     sample_prep: str = 'underivatized', # Sample preparation method: underivatized/permethylated/peracetylated
+                     mass_tolerance: float = 0.5, # Mass tolerance for matching
+                     kingdom: str = 'Animalia', # Taxonomic kingdom filter for choosing a subset of glycans to consider
+                     glycan_class: str = 'all', # Glycan class: N/O/lipid/free/all
+                     df_use: Optional[pd.DataFrame] = None, # Custom glycan database
+                     filter_out: Optional[Set[str]] = None, # Monosaccharides to ignore during composition finding
+                     extras: List[str] = ["doubly_charged"], # Additional operations: adduct/doubly_charged
+                     adduct: Optional[str] = None # Chemical formula of adduct that contributes to m/z, e.g., "C2H4O2"
+                    ) -> List[Dict[str, int]]: # List of matching compositions
+  "Map m/z value to matching monosaccharide composition"
   if df_use is None:
     if glycan_class == "all":
       df_use = df_glycan[df_glycan.Kingdom.apply(lambda x: kingdom in x)]
@@ -305,18 +252,13 @@ def mz_to_composition(mz_value: float, mode: str = 'negative', mass_value: str =
 
 
 @rescue_compositions
-def match_composition_relaxed(composition: dict[str, int], glycan_class: str = 'N', kingdom: str = 'Animalia',
-                              df_use: pd.DataFrame | None = None, reducing_end: str | None = None) -> list[str]:
-  """Given a coarse-grained monosaccharide composition (Hex, HexNAc, etc.), it returns all corresponding glycans\n
-  | Arguments:
-  | :-
-  | composition (dict): a dictionary indicating the composition to match (for example {"dHex": 1, "Hex": 1, "HexNAc": 1})
-  | glycan_class (string): which glycan class does the m/z value stem from, 'N', 'O', or 'lipid' linked glycans or 'free' glycans; default:N
-  | kingdom (string): taxonomic kingdom for choosing a subset of glycans to consider; default:'Animalia'
-  | df_use (dataframe): glycan dataframe for searching glycan structures; default:df_glycan\n
-  | Returns:
-  | :-
-  | Returns list of glycans matching composition in IUPAC-condensed"""
+def match_composition_relaxed(composition: Dict[str, int], # Dictionary indicating composition (e.g. {"dHex": 1, "Hex": 1, "HexNAc": 1})
+                            glycan_class: str = 'N', # Glycan class: N/O/lipid/free
+                            kingdom: str = 'Animalia', # Taxonomic kingdom filter for choosing a subset of glycans to consider
+                            df_use: Optional[pd.DataFrame] = None, # Custom glycan database
+                            reducing_end: Optional[str] = None # Reducing end specification
+                           ) -> List[str]: # List of matching glycans
+  "Map coarse-grained composition to matching glycans"
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   # Subset for glycans with the right number of monosaccharides
@@ -328,14 +270,9 @@ def match_composition_relaxed(composition: dict[str, int], glycan_class: str = '
   return [glycan for glycan, glycan_comp in zip(output_list, output_compositions) if glycan_comp == composition]
 
 
-def condense_composition_matching(matched_composition: list[str]) -> list[str]:
-  """Given a list of glycans matching a composition, find the minimum number of glycans characterizing this set\n
-  | Arguments:
-  | :-
-  | matched_composition (list): list of glycans matching to a composition\n
-  | Returns:
-  | :-
-  | Returns minimal list of glycans that match a composition"""
+def condense_composition_matching(matched_composition: List[str] # List of matching glycans
+                               ) -> List[str]: # Minimal list of representative glycans
+  "Find minimum set of glycans characterizing matched composition"
   # Establish glycan equality given the wildcards
   match_matrix = pd.DataFrame(
     [[compare_glycans(k, j)
@@ -359,21 +296,14 @@ def condense_composition_matching(matched_composition: list[str]) -> list[str]:
 
 
 @rescue_compositions
-def compositions_to_structures(composition_list: list[dict[str, int]], glycan_class: str = 'N', kingdom: str = 'Animalia',
-                               abundances: pd.DataFrame | None = None, df_use: pd.DataFrame | None = None,
-                               verbose: bool = False) -> pd.DataFrame:
-  """wrapper function to map compositions to structures, condense them, and match them with relative intensities\n
-  | Arguments:
-  | :-
-  | composition_list (list): list of composition dictionaries of the form {'Hex': 1, 'HexNAc': 1}
-  | glycan_class (string): which glycan class does the m/z value stem from, 'N', 'O', or 'lipid' linked glycans or 'free' glycans; default:N
-  | kingdom (string): taxonomic kingdom for choosing a subset of glycans to consider; default:'Animalia'
-  | abundances (dataframe): every row one composition (matching composition_list in order), every column one sample;default:pd.DataFrame([range(len(composition_list))]*2).T
-  | df_use (dataframe): glycan dataframe for searching glycan structures; default:df_glycan
-  | verbose (bool): whether to print any non-matching compositions; default:False\n
-  | Returns:
-  | :-
-  | Returns dataframe of (matched structures) x (relative intensities)"""
+def compositions_to_structures(composition_list: List[Dict[str, int]], # List of compositions like {'Hex': 1, 'HexNAc': 1}
+                             glycan_class: str = 'N', # Glycan class: N/O/lipid/free
+                             kingdom: str = 'Animalia', # Taxonomic kingdom filter for choosing a subset of glycans to consider
+                             abundances: Optional[pd.DataFrame] = None, # Sample abundances matrix
+                             df_use: Optional[pd.DataFrame] = None, # Custom glycan database
+                             verbose: bool = False # Whether to print non-matching compositions
+                            ) -> pd.DataFrame: # DataFrame of structures x intensities
+  "Map compositions to structures, supporting accompanying relative intensities"
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   if abundances is None:
@@ -403,28 +333,20 @@ def compositions_to_structures(composition_list: list[dict[str, int]], glycan_cl
   return df_out
 
 
-def mz_to_structures(mz_list: list[float], glycan_class: str, kingdom: str = 'Animalia', abundances: pd.DataFrame | None = None,
-                     mode: str = 'negative', mass_value: str = 'monoisotopic', sample_prep: str = 'underivatized',
-                     mass_tolerance: float = 0.5, reduced: bool = False, df_use: pd.DataFrame | None = None,
-                     filter_out: set[str] | None = None, verbose: bool = False) -> pd.DataFrame | list:
-  """wrapper function to map precursor masses to structures, condense them, and match them with relative intensities\n
-  | Arguments:
-  | :-
-  | mz_list (list): list of precursor masses
-  | glycan_class (string): which glycan class does the m/z value stem from, 'N', 'O', or 'lipid' linked glycans or 'free' glycans
-  | kingdom (string): taxonomic kingdom for choosing a subset of glycans to consider; default:'Animalia'
-  | abundances (dataframe): every row one composition (matching mz_list in order), every column one sample; default:pd.DataFrame([range(len(mz_list))]*2).T
-  | mode (string): whether mz_value comes from MS in 'positive' or 'negative' mode; default:'negative'
-  | mass_value (string): whether the expected mass is 'monoisotopic' or 'average'; default:'monoisotopic'
-  | sample_prep (string): whether the glycans has been 'underivatized', 'permethylated', or 'peracetylated'; default:'underivatized'
-  | mass_tolerance (float): how much deviation to tolerate for a match; default:0.5
-  | reduced (bool): whether glycans are reduced at reducing end; default:False
-  | df_use (dataframe): species-specific glycan dataframe to use for mapping; default: df_glycan
-  | filter_out (set): set of monosaccharide types to ignore during composition finding; default:None
-  | verbose (bool): whether to print any non-matching compositions; default:False\n
-  | Returns:
-  | :-
-  | Returns dataframe of (matched structures) x (relative intensities)"""
+def mz_to_structures(mz_list: List[float], # List of precursor masses
+                    glycan_class: str, # Glycan class: N/O/lipid/free
+                    kingdom: str = 'Animalia', # Taxonomic kingdom filter for choosing a subset of glycans to consider
+                    abundances: Optional[pd.DataFrame] = None, # Sample abundances matrix
+                    mode: str = 'negative', # MS mode: positive/negative
+                    mass_value: str = 'monoisotopic', # Mass type: monoisotopic/average
+                    sample_prep: str = 'underivatized', # Sample prep: underivatized/permethylated/peracetylated
+                    mass_tolerance: float = 0.5, # Mass tolerance for matching
+                    reduced: bool = False, # Whether glycans are reduced
+                    df_use: Optional[pd.DataFrame] = None, # Custom glycan database
+                    filter_out: Optional[Set[str]] = None, # Monosaccharides to ignore
+                    verbose: bool = False # Whether to print non-matching compositions
+                   ) -> Union[pd.DataFrame, List]: # DataFrame of structures x intensities or empty list
+  "Map precursor masses to structures, supporting accompanying relative intensities"
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   if filter_out is None:
@@ -449,16 +371,11 @@ def mz_to_structures(mz_list: list[float], glycan_class: str, kingdom: str = 'An
     return []
 
 
-def mask_rare_glycoletters(glycans: list[str], thresh_monosaccharides: int | None = None, thresh_linkages: int | None = None) -> list[str]:
-  """masks rare monosaccharides and linkages in a list of glycans\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed form
-  | thresh_monosaccharides (int): threshold-value for monosaccharides seen as "rare"; default:(0.001*len(glycans))
-  | thresh_linkages (int): threshold-value for linkages seen as "rare"; default:(0.03*len(glycans))\n
-  | Returns:
-  | :-
-  | Returns list of glycans in IUPAC-condensed with masked rare monosaccharides and linkages"""
+def mask_rare_glycoletters(glycans: List[str], # List of IUPAC-condensed glycans
+                          thresh_monosaccharides: Optional[int] = None, # Threshold for rare monosaccharides (default: 0.001*len(glycans))
+                          thresh_linkages: Optional[int] = None # Threshold for rare linkages (default: 0.03*len(glycans))
+                         ) -> List[str]: # List of glycans with masked rare elements
+  "Mask rare monosaccharides and linkages in glycans"
   # Get rarity thresholds
   if thresh_monosaccharides is None:
     thresh_monosaccharides = int(np.ceil(0.001*len(glycans)))
@@ -493,15 +410,10 @@ def mask_rare_glycoletters(glycans: list[str], thresh_monosaccharides: int | Non
   return out
 
 
-def map_to_basic(glycoletter: str, obfuscate_ptm: bool = True) -> str:
-  """given a monosaccharide/linkage, try to map it to the corresponding base monosaccharide/linkage\n
-  | Arguments:
-  | :-
-  | glycoletter (string): monosaccharide or linkage
-  | obfuscate_ptm (bool): whether to remove position-specific information of PTM or not; default:True\n
-  | Returns:
-  | :-
-  | Returns the base monosaccharide/linkage or the original glycoletter, if it cannot be mapped"""
+def map_to_basic(glycoletter: str, # Monosaccharide or linkage
+                 obfuscate_ptm: bool = True # Whether to remove PTM position specificity
+                ) -> str: # Base monosaccharide/linkage
+  "Map monosaccharide/linkage to corresponding base form"
   conditions = [(Hex, 'Hex'), (dHex, 'dHex'), (HexA, 'HexA'), (HexN, 'HexN'), (HexNAc, 'HexNAc'), (Pen, 'Pen'), (linkages, '?1-?')]
   for cond, ret in conditions:
     if glycoletter in cond:
@@ -524,14 +436,9 @@ def map_to_basic(glycoletter: str, obfuscate_ptm: bool = True) -> str:
   return glycoletter
 
 
-def structure_to_basic(glycan: str) -> str:
-  """converts a monosaccharide- and linkage-defined glycan structure to the base topology\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed nomenclature\n
-  | Returns:
-  | :-
-  | Returns the glycan topology as a string"""
+def structure_to_basic(glycan: str # Glycan in IUPAC-condensed format
+                     ) -> str: # Base topology string
+  "Convert glycan structure to base topology"
   if glycan.endswith('-ol'):
     glycan = glycan[:-3]
   if '(' not in glycan:
@@ -543,15 +450,10 @@ def structure_to_basic(glycan: str) -> str:
 
 
 @rescue_glycans
-def glycan_to_composition(glycan: str, stem_libr: dict[str, str] | None = None) -> dict[str, int]:
-  """maps glycan to its composition\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | stem_libr (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide; default:created from lib\n
-  | Returns:
-  | :-
-  | Returns a dictionary of form "Monosaccharide" : count"""
+def glycan_to_composition(glycan: str, # Glycan in IUPAC-condensed format
+                         stem_libr: Optional[Dict[str, str]] = None # Modified to core monosaccharide mapping; default: created from lib
+                        ) -> Dict[str, int]: # Dictionary of monosaccharide counts
+  "Map glycan to its composition"
   if stem_libr is None:
     stem_libr = stem_lib
   if '{' in glycan:
@@ -574,15 +476,10 @@ def glycan_to_composition(glycan: str, stem_libr: dict[str, str] | None = None) 
     return dict(composition)
 
 
-def calculate_adduct_mass(adduct: str, mass_value: str = 'monoisotopic') -> float:
-  """Calculate the mass of the adduct based on its chemical formula\n
-  | Arguments:
-  | :-
-  | adduct (string): chemical formula of adduct, e.g., "C2H4O2"
-  | mass_value (string): whether to use 'monoisotopic' or 'average' mass; default:'monoisotopic'\n
-  | Returns:
-  | :-
-  | Returns the mass of the adduct"""
+def calculate_adduct_mass(adduct: str, # Chemical formula of adduct (e.g. "C2H4O2")
+                         mass_value: str = 'monoisotopic' # Mass type: monoisotopic/average
+                        ) -> float: # Adduct mass
+  "Calculate mass of adduct from chemical formula"
   element_masses = {
     'monoisotopic': {'C': 12.0000, 'H': 1.0078, 'O': 15.9949, 'N': 14.0031},
     'average': {'C': 12.0107, 'H': 1.00794, 'O': 15.9994, 'N': 14.0067}
@@ -607,18 +504,12 @@ def calculate_adduct_mass(adduct: str, mass_value: str = 'monoisotopic') -> floa
 
 
 @rescue_compositions
-def composition_to_mass(dict_comp_in: dict[str, int], mass_value: str = 'monoisotopic',
-                       sample_prep: str = 'underivatized', adduct: str | None = None) -> float:
-  """given a composition, calculates its theoretical mass; only allowed extra-modifications are methylation, sulfation, phosphorylation\n
-  | Arguments:
-  | :-
-  | dict_comp_in (dict): composition in form monosaccharide:count
-  | mass_value (string): whether the expected mass is 'monoisotopic' or 'average'; default:'monoisotopic'
-  | sample_prep (string): whether the glycans has been 'underivatized', 'permethylated', or 'peracetylated'; default:'underivatized'
-  | adduct (string): chemical formula of adduct to be added, e.g., "C2H4O2"; default:None\n
-  | Returns:
-  | :-
-  | Returns the theoretical mass of input composition"""
+def composition_to_mass(dict_comp_in: Dict[str, int], # Composition dictionary of monosaccharide:count
+                       mass_value: str = 'monoisotopic', # Mass type: monoisotopic/average
+                       sample_prep: str = 'underivatized', # Sample prep: underivatized/permethylated/peracetylated
+                       adduct: Optional[str] = None # Chemical formula of adduct (e.g. "C2H4O2")
+                      ) -> float: # Theoretical mass
+  "Calculate theoretical mass from composition"
   dict_comp = dict_comp_in.copy()
   mass_key = f"{sample_prep}_{mass_value}"
   mass_dict_in = mass_dict if mass_key == "underivatized_monoisotopic" else dict(zip(mapping_file.composition, mapping_file[mass_key]))
@@ -632,19 +523,13 @@ def composition_to_mass(dict_comp_in: dict[str, int], mass_value: str = 'monoiso
   return total_mass
 
 
-def glycan_to_mass(glycan: str, mass_value: str = 'monoisotopic', sample_prep: str = 'underivatized',
-                   stem_libr: dict[str, str] | None = None, adduct: str | None = None) -> float:
-  """given a glycan, calculates its theoretical mass; only allowed extra-modifications are methylation, sulfation, phosphorylation\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | mass_value (string): whether the expected mass is 'monoisotopic' or 'average'; default:'monoisotopic'
-  | sample_prep (string): whether the glycans has been 'underivatized', 'permethylated', or 'peracetylated'; default:'underivatized'
-  | stem_libr (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide; default:created from lib
-  | adduct (string): chemical formula of adduct to be added, e.g., "C2H4O2"; default:None\n
-  | Returns:
-  | :-
-  | Returns the theoretical mass of input glycan"""
+def glycan_to_mass(glycan: str, # Glycan in IUPAC-condensed format
+                   mass_value: str = 'monoisotopic', # Mass type: monoisotopic/average
+                   sample_prep: str = 'underivatized', # Sample prep: underivatized/permethylated/peracetylated
+                   stem_libr: Optional[Dict[str, str]] = None, # Modified to core monosaccharide mapping
+                   adduct: Optional[str] = None # Chemical formula of adduct (e.g. "C2H4O2")
+                  ) -> float: # Theoretical mass
+  "Calculate theoretical mass from glycan"
   if stem_libr is None:
     stem_libr = stem_lib
   comp = glycan_to_composition(glycan, stem_libr = stem_libr)
@@ -652,20 +537,14 @@ def glycan_to_mass(glycan: str, mass_value: str = 'monoisotopic', sample_prep: s
 
 
 @rescue_compositions
-def get_unique_topologies(composition: dict[str, int], glycan_type: str, df_use: pd.DataFrame | None = None,
-                         universal_replacers: dict[str, str] | None = None, taxonomy_rank: str = "Kingdom", taxonomy_value: str = "Animalia") -> list[str]:
-  """given a composition, retrieves all observed and unique base topologies\n
-  | Arguments:
-  | :-
-  | composition (dict): composition in form monosaccharide:count
-  | glycan_type (string): which glycan class to search, 'N', 'O', 'lipid', 'free', or 'repeat'
-  | df_use (dataframe): species-specific glycan dataframe to use for mapping; default: df_glycan
-  | universal_replacers (dictionary): dictionary of form base monosaccharide : specific monosaccharide
-  | taxonomy_rank (string): at which taxonomic rank to filter; default: Kingdom
-  | taxonomy_value (string): which value to filter at taxonomy_rank; default: Animalia\n
-  | Returns:
-  | :-
-  | Returns a list of observed base topologies for the given composition"""
+def get_unique_topologies(composition: Dict[str, int], # Composition dictionary of monosaccharide:count
+                         glycan_type: str, # Glycan class: N/O/lipid/free/repeat
+                         df_use: Optional[pd.DataFrame] = None, # Custom glycan database to use for mapping
+                         universal_replacers: Optional[Dict[str, str]] = None, # Base-to-specific monosaccharide mapping
+                         taxonomy_rank: str = "Kingdom", # Taxonomic rank for filtering
+                         taxonomy_value: str = "Animalia" # Value at taxonomy rank
+                        ) -> List[str]: # List of unique base topologies
+  "Get all observed unique base topologies for composition"
   if df_use is None:
     df_use = df_glycan
   if universal_replacers is None:

--- a/glycowork/motif/tokenization.py
+++ b/glycowork/motif/tokenization.py
@@ -20,7 +20,7 @@ with resources.open_text("glycowork.motif", "mz_to_composition.csv") as f:
 mass_dict = dict(zip(mapping_file.composition, mapping_file["underivatized_monoisotopic"]))
 
 
-def constrain_prot(proteins, libr = None):
+def constrain_prot(proteins: list[str], libr: dict[str, int] | None = None) -> list[str]:
   """Ensures that no characters outside of libr are present in proteins\n
   | Arguments:
   | :-
@@ -36,7 +36,7 @@ def constrain_prot(proteins, libr = None):
   return [''.join(c if c in libr_set else 'z' for c in protein) for protein in proteins]
 
 
-def prot_to_coded(proteins, libr = None, pad_len = 1000):
+def prot_to_coded(proteins: list[str], libr: dict[str, int] | None = None, pad_len: int = 1000) -> list[list[int]]:
   """Encodes protein sequences to be used in LectinOracle-flex\n
   | Arguments:
   | :-
@@ -59,7 +59,7 @@ def prot_to_coded(proteins, libr = None, pad_len = 1000):
   return encoded_prots
 
 
-def string_to_labels(character_string, libr = None):
+def string_to_labels(character_string: str, libr: dict[str, int] | None = None) -> list[int]:
   """tokenizes word by indexing characters in passed library\n
   | Arguments:
   | :-
@@ -73,7 +73,7 @@ def string_to_labels(character_string, libr = None):
   return list(map(libr.get, character_string))
 
 
-def pad_sequence(seq, max_length, pad_label = None, libr = None):
+def pad_sequence(seq: list[int], max_length: int, pad_label: int | None = None, libr: dict[str, int] | None = None) -> list[int]:
   """brings all sequences to same length by adding padding token\n
   | Arguments:
   | :-
@@ -94,7 +94,7 @@ def pad_sequence(seq, max_length, pad_label = None, libr = None):
   return seq
 
 
-def get_core(sugar):
+def get_core(sugar: str) -> str:
   """retrieves core monosaccharide from modified monosaccharide\n
   | Arguments:
   | :-
@@ -132,7 +132,7 @@ def get_core(sugar):
   return 'Monosaccharide'
 
 
-def get_modification(sugar):
+def get_modification(sugar: str) -> str:
   """retrieves modification from modified monosaccharide\n
   | Arguments:
   | :-
@@ -145,7 +145,7 @@ def get_modification(sugar):
   return modification
 
 
-def get_stem_lib(libr):
+def get_stem_lib(libr: dict[str, int]) -> dict[str, str]:
   """creates a mapping file to map modified monosaccharides to core monosaccharides\n
   | Arguments:
   | :-
@@ -159,7 +159,7 @@ def get_stem_lib(libr):
 stem_lib = get_stem_lib(lib)
 
 
-def stemify_glycan(glycan, stem_lib = None, libr = None):
+def stemify_glycan(glycan: str, stem_lib: dict[str, str] | None = None, libr: dict[str, int] | None = None) -> str:
   """removes modifications from all monosaccharides in a glycan\n
   | Arguments:
   | :-
@@ -216,8 +216,8 @@ def stemify_glycan(glycan, stem_lib = None, libr = None):
   return glycan
 
 
-def stemify_dataset(df, stem_lib = None, libr = None,
-                    glycan_col_name = 'glycan', rarity_filter = 1):
+def stemify_dataset(df: pd.DataFrame, stem_lib: dict[str, str] | None = None, libr: dict[str, int] | None = None,
+                    glycan_col_name: str = 'glycan', rarity_filter: int = 1) -> pd.DataFrame:
   """stemifies all glycans in a dataset by removing monosaccharide modifications\n
   | Arguments:
   | :-
@@ -243,9 +243,10 @@ def stemify_dataset(df, stem_lib = None, libr = None,
   return df_out
 
 
-def mz_to_composition(mz_value, mode = 'negative', mass_value = 'monoisotopic', reduced = False,
-                      sample_prep = 'underivatized', mass_tolerance = 0.5, kingdom = 'Animalia',
-                      glycan_class = 'all', df_use = None, filter_out = None, extras = ["doubly_charged"], adduct = None):
+def mz_to_composition(mz_value: float, mode: str = 'negative', mass_value: str = 'monoisotopic', reduced: bool = False,
+                      sample_prep: str = 'underivatized', mass_tolerance: float = 0.5, kingdom: str = 'Animalia',
+                      glycan_class: str = 'all', df_use: pd.DataFrame | None = None, filter_out: set[str] | None = None,
+                      extras: list[str] = ["doubly_charged"], adduct: str | None = None) -> list[dict[str, int]]:
   """Mapping a m/z value to a matching monosaccharide composition within SugarBase\n
   | Arguments:
   | :-
@@ -304,7 +305,8 @@ def mz_to_composition(mz_value, mode = 'negative', mass_value = 'monoisotopic', 
 
 
 @rescue_compositions
-def match_composition_relaxed(composition, glycan_class = 'N', kingdom = 'Animalia', df_use = None, reducing_end = None):
+def match_composition_relaxed(composition: dict[str, int], glycan_class: str = 'N', kingdom: str = 'Animalia',
+                              df_use: pd.DataFrame | None = None, reducing_end: str | None = None) -> list[str]:
   """Given a coarse-grained monosaccharide composition (Hex, HexNAc, etc.), it returns all corresponding glycans\n
   | Arguments:
   | :-
@@ -326,7 +328,7 @@ def match_composition_relaxed(composition, glycan_class = 'N', kingdom = 'Animal
   return [glycan for glycan, glycan_comp in zip(output_list, output_compositions) if glycan_comp == composition]
 
 
-def condense_composition_matching(matched_composition):
+def condense_composition_matching(matched_composition: list[str]) -> list[str]:
   """Given a list of glycans matching a composition, find the minimum number of glycans characterizing this set\n
   | Arguments:
   | :-
@@ -357,8 +359,9 @@ def condense_composition_matching(matched_composition):
 
 
 @rescue_compositions
-def compositions_to_structures(composition_list, glycan_class = 'N', kingdom = 'Animalia', abundances = None,
-                               df_use = None, verbose = False):
+def compositions_to_structures(composition_list: list[dict[str, int]], glycan_class: str = 'N', kingdom: str = 'Animalia',
+                               abundances: pd.DataFrame | None = None, df_use: pd.DataFrame | None = None,
+                               verbose: bool = False) -> pd.DataFrame:
   """wrapper function to map compositions to structures, condense them, and match them with relative intensities\n
   | Arguments:
   | :-
@@ -400,9 +403,10 @@ def compositions_to_structures(composition_list, glycan_class = 'N', kingdom = '
   return df_out
 
 
-def mz_to_structures(mz_list, glycan_class, kingdom = 'Animalia', abundances = None, mode = 'negative',
-                     mass_value = 'monoisotopic', sample_prep = 'underivatized', mass_tolerance = 0.5,
-                     reduced = False, df_use = None, filter_out = None, verbose = False):
+def mz_to_structures(mz_list: list[float], glycan_class: str, kingdom: str = 'Animalia', abundances: pd.DataFrame | None = None,
+                     mode: str = 'negative', mass_value: str = 'monoisotopic', sample_prep: str = 'underivatized',
+                     mass_tolerance: float = 0.5, reduced: bool = False, df_use: pd.DataFrame | None = None,
+                     filter_out: set[str] | None = None, verbose: bool = False) -> pd.DataFrame | list:
   """wrapper function to map precursor masses to structures, condense them, and match them with relative intensities\n
   | Arguments:
   | :-
@@ -445,7 +449,7 @@ def mz_to_structures(mz_list, glycan_class, kingdom = 'Animalia', abundances = N
     return []
 
 
-def mask_rare_glycoletters(glycans, thresh_monosaccharides = None, thresh_linkages = None):
+def mask_rare_glycoletters(glycans: list[str], thresh_monosaccharides: int | None = None, thresh_linkages: int | None = None) -> list[str]:
   """masks rare monosaccharides and linkages in a list of glycans\n
   | Arguments:
   | :-
@@ -489,7 +493,7 @@ def mask_rare_glycoletters(glycans, thresh_monosaccharides = None, thresh_linkag
   return out
 
 
-def map_to_basic(glycoletter, obfuscate_ptm = True):
+def map_to_basic(glycoletter: str, obfuscate_ptm: bool = True) -> str:
   """given a monosaccharide/linkage, try to map it to the corresponding base monosaccharide/linkage\n
   | Arguments:
   | :-
@@ -520,7 +524,7 @@ def map_to_basic(glycoletter, obfuscate_ptm = True):
   return glycoletter
 
 
-def structure_to_basic(glycan):
+def structure_to_basic(glycan: str) -> str:
   """converts a monosaccharide- and linkage-defined glycan structure to the base topology\n
   | Arguments:
   | :-
@@ -539,7 +543,7 @@ def structure_to_basic(glycan):
 
 
 @rescue_glycans
-def glycan_to_composition(glycan, stem_libr = None):
+def glycan_to_composition(glycan: str, stem_libr: dict[str, str] | None = None) -> dict[str, int]:
   """maps glycan to its composition\n
   | Arguments:
   | :-
@@ -570,7 +574,7 @@ def glycan_to_composition(glycan, stem_libr = None):
     return dict(composition)
 
 
-def calculate_adduct_mass(adduct, mass_value = 'monoisotopic'):
+def calculate_adduct_mass(adduct: str, mass_value: str = 'monoisotopic') -> float:
   """Calculate the mass of the adduct based on its chemical formula\n
   | Arguments:
   | :-
@@ -603,7 +607,8 @@ def calculate_adduct_mass(adduct, mass_value = 'monoisotopic'):
 
 
 @rescue_compositions
-def composition_to_mass(dict_comp_in, mass_value = 'monoisotopic', sample_prep = 'underivatized', adduct = None):
+def composition_to_mass(dict_comp_in: dict[str, int], mass_value: str = 'monoisotopic',
+                       sample_prep: str = 'underivatized', adduct: str | None = None) -> float:
   """given a composition, calculates its theoretical mass; only allowed extra-modifications are methylation, sulfation, phosphorylation\n
   | Arguments:
   | :-
@@ -627,7 +632,8 @@ def composition_to_mass(dict_comp_in, mass_value = 'monoisotopic', sample_prep =
   return total_mass
 
 
-def glycan_to_mass(glycan, mass_value = 'monoisotopic', sample_prep = 'underivatized', stem_libr = None, adduct = None):
+def glycan_to_mass(glycan: str, mass_value: str = 'monoisotopic', sample_prep: str = 'underivatized',
+                   stem_libr: dict[str, str] | None = None, adduct: str | None = None) -> float:
   """given a glycan, calculates its theoretical mass; only allowed extra-modifications are methylation, sulfation, phosphorylation\n
   | Arguments:
   | :-
@@ -646,8 +652,8 @@ def glycan_to_mass(glycan, mass_value = 'monoisotopic', sample_prep = 'underivat
 
 
 @rescue_compositions
-def get_unique_topologies(composition, glycan_type, df_use = None, universal_replacers = None,
-                         taxonomy_rank = "Kingdom", taxonomy_value = "Animalia"):
+def get_unique_topologies(composition: dict[str, int], glycan_type: str, df_use: pd.DataFrame | None = None,
+                         universal_replacers: dict[str, str] | None = None, taxonomy_rank: str = "Kingdom", taxonomy_value: str = "Animalia") -> list[str]:
   """given a composition, retrieves all observed and unique base topologies\n
   | Arguments:
   | :-

--- a/glycowork/motif/tokenization.py
+++ b/glycowork/motif/tokenization.py
@@ -28,8 +28,7 @@ def constrain_prot(proteins, libr = None):
   | libr (list): sorted list of amino acids occurring in proteins\n
   | Returns:
   | :-
-  | Returns list of proteins with only permitted amino acids
-  """
+  | Returns list of proteins with only permitted amino acids"""
   if libr is None:
     libr = chars
   # Check whether any character is not in libr and replace it with a 'z' placeholder character
@@ -46,8 +45,7 @@ def prot_to_coded(proteins, libr = None, pad_len = 1000):
   | pad_len (int): length up to which the proteins are padded\n
   | Returns:
   | :-
-  | Returns list of encoded proteins with only permitted amino acids
-  """
+  | Returns list of encoded proteins with only permitted amino acids"""
   if libr is None:
     libr = chars
   pad_label = len(libr) - 1
@@ -69,8 +67,7 @@ def string_to_labels(character_string, libr = None):
   | libr (dict): dict of library items\n
   | Returns:
   | :-
-  | Returns indexes of characters in library
-  """
+  | Returns indexes of characters in library"""
   if libr is None:
     libr = chars
   return list(map(libr.get, character_string))
@@ -83,11 +80,10 @@ def pad_sequence(seq, max_length, pad_label = None, libr = None):
   | seq (list): sequence to pad (from string_to_labels)
   | max_length (int): sequence length to pad to
   | pad_label (int): which padding label to use
-  | libr (list): list of library items\n\n
+  | libr (list): list of library items\n
   | Returns:
   | :-
-  | Returns padded sequence
-  """
+  | Returns padded sequence"""
   if libr is None:
     libr = chars
   if pad_label is None:
@@ -105,8 +101,7 @@ def get_core(sugar):
   | sugar (string): monosaccharide or linkage\n
   | Returns:
   | :-
-  | Returns core monosaccharide as string
-  """
+  | Returns core monosaccharide as string"""
   easy_cores = set(['dHexNAc', 'GlcNAc', 'GalNAc', 'ManNAc', 'FucNAc', 'QuiNAc', 'RhaNAc', 'GulNAc',
                 'IdoNAc', 'Ins', 'MurNAc', '6dAltNAc', 'AcoNAc', 'HexA', 'GlcA', 'AltA',
                 'GalA', 'ManA', 'Tyv', 'Yer', 'Abe', 'GlcfNAc', 'GalfNAc', 'ManfNAc',
@@ -144,8 +139,7 @@ def get_modification(sugar):
   | sugar (string): monosaccharide or linkage\n
   | Returns:
   | :-
-  | Returns modification as string
-  """
+  | Returns modification as string"""
   core = get_core(sugar)
   modification = sugar.replace(core, '')
   return modification
@@ -158,8 +152,7 @@ def get_stem_lib(libr):
   | libr (dict): dictionary of form glycoletter:index\n
   | Returns:
   | :-
-  | Returns dictionary of form modified_monosaccharide:core_monosaccharide
-  """
+  | Returns dictionary of form modified_monosaccharide:core_monosaccharide"""
   return {k: get_core(k) for k in libr}
 
 
@@ -175,8 +168,7 @@ def stemify_glycan(glycan, stem_lib = None, libr = None):
   | libr (dict): dictionary of form glycoletter:index; default:lib\n
   | Returns:
   | :-
-  | Returns stemmed glycan as string
-  """
+  | Returns stemmed glycan as string"""
   if libr is None:
     libr = lib
   if stem_lib is None:
@@ -236,8 +228,7 @@ def stemify_dataset(df, stem_lib = None, libr = None,
   | rarity_filter (int): how often monosaccharide modification has to occur to not get removed; default:1\n
   | Returns:
   | :-
-  | Returns df with glycans stemified
-  """
+  | Returns df with glycans stemified"""
   if libr is None:
     libr = lib
   if stem_lib is None:
@@ -272,8 +263,7 @@ def mz_to_composition(mz_value, mode = 'negative', mass_value = 'monoisotopic', 
   | adduct (string): chemical formula of adduct that contributes to m/z, e.g., "C2H4O2"; default:None\n
   | Returns:
   | :-
-  | Returns a list of matching compositions in dict form
-  """
+  | Returns a list of matching compositions in dict form"""
   if df_use is None:
     if glycan_class == "all":
       df_use = df_glycan[df_glycan.Kingdom.apply(lambda x: kingdom in x)]
@@ -324,8 +314,7 @@ def match_composition_relaxed(composition, glycan_class = 'N', kingdom = 'Animal
   | df_use (dataframe): glycan dataframe for searching glycan structures; default:df_glycan\n
   | Returns:
   | :-
-  | Returns list of glycans matching composition in IUPAC-condensed
-  """
+  | Returns list of glycans matching composition in IUPAC-condensed"""
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   # Subset for glycans with the right number of monosaccharides
@@ -344,8 +333,7 @@ def condense_composition_matching(matched_composition):
   | matched_composition (list): list of glycans matching to a composition\n
   | Returns:
   | :-
-  | Returns minimal list of glycans that match a composition
-  """
+  | Returns minimal list of glycans that match a composition"""
   # Establish glycan equality given the wildcards
   match_matrix = pd.DataFrame(
     [[compare_glycans(k, j)
@@ -382,8 +370,7 @@ def compositions_to_structures(composition_list, glycan_class = 'N', kingdom = '
   | verbose (bool): whether to print any non-matching compositions; default:False\n
   | Returns:
   | :-
-  | Returns dataframe of (matched structures) x (relative intensities)
-  """
+  | Returns dataframe of (matched structures) x (relative intensities)"""
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   if abundances is None:
@@ -433,8 +420,7 @@ def mz_to_structures(mz_list, glycan_class, kingdom = 'Animalia', abundances = N
   | verbose (bool): whether to print any non-matching compositions; default:False\n
   | Returns:
   | :-
-  | Returns dataframe of (matched structures) x (relative intensities)
-  """
+  | Returns dataframe of (matched structures) x (relative intensities)"""
   if df_use is None:
     df_use = df_glycan[(df_glycan.glycan_type == glycan_class) & (df_glycan.Kingdom.apply(lambda x: kingdom in x))]
   if filter_out is None:
@@ -468,8 +454,7 @@ def mask_rare_glycoletters(glycans, thresh_monosaccharides = None, thresh_linkag
   | thresh_linkages (int): threshold-value for linkages seen as "rare"; default:(0.03*len(glycans))\n
   | Returns:
   | :-
-  | Returns list of glycans in IUPAC-condensed with masked rare monosaccharides and linkages
-  """
+  | Returns list of glycans in IUPAC-condensed with masked rare monosaccharides and linkages"""
   # Get rarity thresholds
   if thresh_monosaccharides is None:
     thresh_monosaccharides = int(np.ceil(0.001*len(glycans)))
@@ -512,8 +497,7 @@ def map_to_basic(glycoletter, obfuscate_ptm = True):
   | obfuscate_ptm (bool): whether to remove position-specific information of PTM or not; default:True\n
   | Returns:
   | :-
-  | Returns the base monosaccharide/linkage or the original glycoletter, if it cannot be mapped
-  """
+  | Returns the base monosaccharide/linkage or the original glycoletter, if it cannot be mapped"""
   conditions = [(Hex, 'Hex'), (dHex, 'dHex'), (HexA, 'HexA'), (HexN, 'HexN'), (HexNAc, 'HexNAc'), (Pen, 'Pen'), (linkages, '?1-?')]
   for cond, ret in conditions:
     if glycoletter in cond:
@@ -543,8 +527,7 @@ def structure_to_basic(glycan):
   | glycan (string): glycan in IUPAC-condensed nomenclature\n
   | Returns:
   | :-
-  | Returns the glycan topology as a string
-  """
+  | Returns the glycan topology as a string"""
   if glycan.endswith('-ol'):
     glycan = glycan[:-3]
   if '(' not in glycan:
@@ -564,8 +547,7 @@ def glycan_to_composition(glycan, stem_libr = None):
   | stem_libr (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide; default:created from lib\n
   | Returns:
   | :-
-  | Returns a dictionary of form "Monosaccharide" : count
-  """
+  | Returns a dictionary of form "Monosaccharide" : count"""
   if stem_libr is None:
     stem_libr = stem_lib
   if '{' in glycan:
@@ -596,8 +578,7 @@ def calculate_adduct_mass(adduct, mass_value = 'monoisotopic'):
   | mass_value (string): whether to use 'monoisotopic' or 'average' mass; default:'monoisotopic'\n
   | Returns:
   | :-
-  | Returns the mass of the adduct
-  """
+  | Returns the mass of the adduct"""
   element_masses = {
     'monoisotopic': {'C': 12.0000, 'H': 1.0078, 'O': 15.9949, 'N': 14.0031},
     'average': {'C': 12.0107, 'H': 1.00794, 'O': 15.9994, 'N': 14.0067}
@@ -622,18 +603,18 @@ def calculate_adduct_mass(adduct, mass_value = 'monoisotopic'):
 
 
 @rescue_compositions
-def composition_to_mass(dict_comp, mass_value = 'monoisotopic', sample_prep = 'underivatized', adduct = None):
+def composition_to_mass(dict_comp_in, mass_value = 'monoisotopic', sample_prep = 'underivatized', adduct = None):
   """given a composition, calculates its theoretical mass; only allowed extra-modifications are methylation, sulfation, phosphorylation\n
   | Arguments:
   | :-
-  | dict_comp (dict): composition in form monosaccharide:count
+  | dict_comp_in (dict): composition in form monosaccharide:count
   | mass_value (string): whether the expected mass is 'monoisotopic' or 'average'; default:'monoisotopic'
   | sample_prep (string): whether the glycans has been 'underivatized', 'permethylated', or 'peracetylated'; default:'underivatized'
   | adduct (string): chemical formula of adduct to be added, e.g., "C2H4O2"; default:None\n
   | Returns:
   | :-
-  | Returns the theoretical mass of input composition
-  """
+  | Returns the theoretical mass of input composition"""
+  dict_comp = dict_comp_in.copy()
   mass_key = f"{sample_prep}_{mass_value}"
   mass_dict_in = mass_dict if mass_key == "underivatized_monoisotopic" else dict(zip(mapping_file.composition, mapping_file[mass_key]))
   for old_key, new_key in {'S': 'Sulphate', 'P': 'Phosphate', 'Me': 'Methyl', 'Ac': 'Acetate'}.items():
@@ -657,8 +638,7 @@ def glycan_to_mass(glycan, mass_value = 'monoisotopic', sample_prep = 'underivat
   | adduct (string): chemical formula of adduct to be added, e.g., "C2H4O2"; default:None\n
   | Returns:
   | :-
-  | Returns the theoretical mass of input glycan
-  """
+  | Returns the theoretical mass of input glycan"""
   if stem_libr is None:
     stem_libr = stem_lib
   comp = glycan_to_composition(glycan, stem_libr = stem_libr)
@@ -679,8 +659,7 @@ def get_unique_topologies(composition, glycan_type, df_use = None, universal_rep
   | taxonomy_value (string): which value to filter at taxonomy_rank; default: Animalia\n
   | Returns:
   | :-
-  | Returns a list of observed base topologies for the given composition
-  """
+  | Returns a list of observed base topologies for the given composition"""
   if df_use is None:
     df_use = df_glycan
   if universal_replacers is None:

--- a/glycowork/motif/tokenization.py
+++ b/glycowork/motif/tokenization.py
@@ -272,7 +272,7 @@ def mz_to_composition(mz_value, mode = 'negative', mass_value = 'monoisotopic', 
   if filter_out is None:
     filter_out = set()
   if adduct:
-    mz -= calculate_adduct_mass(adduct, mass_value)
+    mz_value -= calculate_adduct_mass(adduct, mass_value)
   adduct_mass = mass_dict['Acetate'] if mode == 'negative' else mass_dict['Na+']
   if reduced:
     mz_value -= 1.0078

--- a/glycowork/network/biosynthesis.py
+++ b/glycowork/network/biosynthesis.py
@@ -10,6 +10,7 @@ from collections import defaultdict, Counter
 from scipy.stats import ttest_rel, ttest_ind
 from statsmodels.formula.api import ols
 from statsmodels.stats.multitest import multipletests
+from typing import Dict, List, Set, Union, Optional, Tuple, Any, FrozenSet
 import statsmodels.api as sm
 import networkx as nx
 import numpy as np
@@ -38,45 +39,29 @@ allowed_ptms = frozenset({'OS', '3S', '6S', 'OP', '1P', '3P', '6P', 'OAc', '4Ac'
 
 
 @lru_cache(maxsize = None)
-def safe_compare(g1: nx.Graph, g2: nx.Graph) -> bool:
-  """Compare_glycans with try/except error catch\n
-  | Arguments:
-  | :-
-  | g1 (networkx object): glycan graph from glycan_to_nxGraph
-  | g2 (networkx object): glycan graph from glycan_to_nxGraph\n
-  | Returns:
-  | :-
-  | Returns True if two glycans are the same and False if not; returns False if 'except' is triggered"""
+def safe_compare(g1: nx.Graph, # First glycan graph
+                g2: nx.Graph # Second glycan graph
+               ) -> bool: # True if glycans are same
+  "Compare glycans with error catch, returning False on exception"
   try:
     return compare_glycans(g1, g2)
   except:
     return False
 
 
-def safe_index(glycan: str, graph_dic: dict[str, nx.Graph]) -> nx.Graph:
-  """Retrieves glycan graph and if not present in graph_dic it will freshly calculate\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph\n
-  | Returns:
-  | :-
-  | Returns a glycan graph, either from graph_dic or freshly generated"""
+def safe_index(glycan: str, # Glycan in IUPAC-condensed format
+              graph_dic: Dict[str, nx.Graph] # Dictionary of glycan:graph mappings
+             ) -> nx.Graph: # Glycan graph
+  "Retrieve glycan graph from dictionary or calculate if not present"
   return graph_dic.setdefault(glycan, glycan_to_nxGraph(glycan))
 
 
-def get_neighbors(ggraph: nx.Graph, glycans: list[str], graphs: list[nx.Graph], min_size: int = 1) -> tuple[list[str], list[list[int]]]:
-  """Find (observed) biosynthetic precursors of a glycan\n
-  | Arguments:
-  | :-
-  | ggraph (networkx): glycan graph as networkx object
-  | glycans (list): list of glycans in IUPAC-condensed format
-  | graphs (list): list of glycans in df as graphs
-  | min_size (int): length of smallest root in biosynthetic network; default:1\n
-  | Returns:
-  | :-
-  | (1) a list of direct glycan precursors in IUPAC-condensed
-  | (2) a list of indices where each precursor from (1) can be found in glycans"""
+def get_neighbors(ggraph: nx.Graph, # Glycan graph
+                 glycans: List[str], # List of glycans in IUPAC-condensed
+                 graphs: List[nx.Graph], # List of glycan graphs
+                 min_size: int = 1 # Minimum root size; default:1
+                ) -> Tuple[List[str], List[List[int]]]: # (Precursor glycans, Index lists for finding precursors in glycans)
+  "Find observed biosynthetic precursors of a glycan"
   # Get graph; graphs of single monosaccharide can't have precursors
   if len(ggraph.nodes()) <= 1:
     return [], []
@@ -89,15 +74,10 @@ def get_neighbors(ggraph: nx.Graph, glycans: list[str], graphs: list[nx.Graph], 
 
 
 @lru_cache(maxsize = None)
-def create_neighbors(ggraph: nx.Graph, min_size: int = 1) -> list[nx.Graph]:
-  """Creates biosynthetic precursor glycans\n
-  | Arguments:
-  | :-
-  | ggraph (networkx object): glycan graph from glycan_to_nxGraph
-  | min_size (int): length of smallest root in biosynthetic network; default:1\n
-  | Returns:
-  | :-
-  | Returns biosynthetic precursor glycans"""
+def create_neighbors(ggraph: nx.Graph, # Glycan graph
+                    min_size: int = 1 # Minimum root size; default:1
+                   ) -> List[nx.Graph]: # List of precursor graphs
+  "Create biosynthetic precursor glycans"
   num_nodes = len(ggraph.nodes())
   # Check whether glycan large enough to allow for precursors
   if num_nodes <= min_size:
@@ -115,17 +95,11 @@ def create_neighbors(ggraph: nx.Graph, min_size: int = 1) -> list[nx.Graph]:
     ]
 
 
-def get_virtual_nodes(glycan: str, graph_dic: dict[str, nx.Graph], min_size: int = 1) -> tuple[list[nx.Graph], list[str]]:
-  """Find unobserved biosynthetic precursors of a glycan\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | min_size (int): length of smallest root in biosynthetic network; default:1\n
-  | Returns:
-  | :-
-  | (1) list of virtual node graphs
-  | (2) list of virtual nodes in IUPAC-condensed format"""
+def get_virtual_nodes(glycan: str, # Glycan in IUPAC-condensed
+                     graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                     min_size: int = 1 # Minimum root size; default:1
+                    ) -> Tuple[List[nx.Graph], List[str]]: # (List of virtual graphs, List of virtual glycans)
+  "Find unobserved biosynthetic precursors of a glycan"
   if glycan.count('(') + 1 <= min_size:
     return [], []
   # Get glycan graph
@@ -138,17 +112,12 @@ def get_virtual_nodes(glycan: str, graph_dic: dict[str, nx.Graph], min_size: int
   return ggraph_nb, ggraph_nb_t2
 
 
-def find_diff(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], allowed_ptms: frozenset[str] = allowed_ptms) -> str:
-  """Finds the subgraph that differs between glycans and returns it, will only work if the differing subgraph is connected\n
-  | Arguments:
-  | :-
-  | glycan_a (networkx): glycan graph as networkx object
-  | glycan_b (networkx): glycan graph as networkx object
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | allowed_ptms (set): list of PTMs to consider\n
-  | Returns:
-  | :-
-  | Returns difference between glycan_a and glycan_b in IUPAC-condensed"""
+def find_diff(glycan_a: str, # First glycan
+             glycan_b: str, # Second glycan
+             graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+             allowed_ptms: FrozenSet[str] = allowed_ptms # Set of allowed PTMs
+            ) -> str: # Differing subgraph or 'disregard'
+  "Find connected subgraph differing between glycans"
   # Check whether the glycans are equal
   if glycan_a == glycan_b:
     return ""
@@ -163,17 +132,12 @@ def find_diff(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], allo
   return 'disregard'
 
 
-def find_shared_virtuals(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], min_size: int = 1) -> list[tuple[str, str]]:
-  """Finds virtual nodes that are shared between two glycans (i.e., that connect these two glycans)\n
-  | Arguments:
-  | :-
-  | glycan_a (string): glycan in IUPAC-condensed format
-  | glycan_b (string): glycan in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | min_size (int): length of smallest root in biosynthetic network; default:1\n
-  | Returns:
-  | :-
-  | Returns list of edges between glycan and virtual node (if virtual node connects the two glycans)"""
+def find_shared_virtuals(glycan_a: str, # First glycan
+                        glycan_b: str, # Second glycan
+                        graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                        min_size: int = 1 # Minimum root size; default:1
+                       ) -> List[Tuple[str, str]]: # List of virtual edge tuples connecting glycans
+  "Find virtual nodes shared between two glycans"
   if abs(glycan_a.count('(') - glycan_b.count('(')) != 2:
     return []
   # Get virtual nodes of both glycans
@@ -188,30 +152,19 @@ def find_shared_virtuals(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.G
   return list(out)
 
 
-def adjacencyMatrix_to_network(adjacency_matrix: pd.DataFrame) -> nx.Graph:
-  """Converts an adjacency matrix to a network\n
-  | Arguments:
-  | :-
-  | adjacency_matrix (dataframe): denoting whether two glycans are connected by one biosynthetic step\n
-  | Returns:
-  | :-
-  | Returns biosynthetic network as a networkx graph"""
+def adjacencyMatrix_to_network(adjacency_matrix: pd.DataFrame # Matrix of biosynthetic connections
+                            ) -> nx.Graph: # Biosynthetic network
+  "Convert adjacency matrix to network"
   network = nx.from_pandas_adjacency(adjacency_matrix)
   network = nx.relabel_nodes(network, {k: c for k, c in enumerate(adjacency_matrix.columns)})
   return network
 
 
-def create_adjacency_matrix(glycans: list[str], graph_dic: dict[str, nx.Graph], min_size: int = 1) -> tuple[nx.Graph, list[str]]:
-  """Creates a biosynthetic adjacency matrix from a list of glycans\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | min_size (int): length of smallest root in biosynthetic network; default:1\n
-  | Returns:
-  | :-
-  | (1) adjacency matrix (glycan X glycan) denoting whether two glycans are connected by one biosynthetic step
-  | (2) list of which nodes are virtual nodes (empty list if virtual_nodes is False)"""
+def create_adjacency_matrix(glycans: List[str], # List of glycans
+                          graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                          min_size: int = 1 # Minimum root size; default:1
+                         ) -> Tuple[nx.Graph, List[str]]: # (Network, Virtual nodes)
+  "Create biosynthetic adjacency matrix from glycan list"
   # Connect glycans with biosynthetic precursors
   df_out = pd.DataFrame(0, index = glycans, columns = glycans)
   graphs = [safe_index(g, graph_dic) for g in glycans]
@@ -244,34 +197,22 @@ def create_adjacency_matrix(glycans: list[str], graph_dic: dict[str, nx.Graph], 
   return adjacencyMatrix_to_network(df_out.add(df_out.T, fill_value = 0)), new_nodes
 
 
-def shells_to_edges(prev_shell: list[list[str]], next_shell: list[list[str]]) -> list[list[tuple[str, str]]]:
-  """Map virtual node generations to edges\n
-  | Arguments:
-  | :-
-  | prev_shell (list): virtual node generation from previous run of propagate_virtuals
-  | next_shell (list): virtual node generation from next run of propagate_virtuals\n
-  | Returns:
-  | :-
-  | Returns mapped edges between two virtual node generations"""
+def shells_to_edges(prev_shell: List[List[str]], # Previous generation virtual nodes
+                   next_shell: List[List[str]] # Next generation virtual nodes
+                  ) -> List[List[Tuple[str, str]]]: # Edge lists between generations
+  "Map virtual node generations to edges"
   # Find connections/edges between virtual nodes from propagate_virtuals run N and propagate_virtuals run N+1
   return [unwrap([[(prev_shell[m][k], next_shell[k][j]) for j in range(len(next_shell[k]))] for k in range(len(prev_shell[m]))]) for m in range(len(prev_shell))]
 
 
-def find_path(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
-              min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> tuple[list[tuple[str, str]], dict[tuple[str, str], str]]:
-  """Find virtual node path between two glycans\n
-  | Arguments:
-  | :-
-  | glycan_a (string): glycan in IUPAC-condensed format
-  | glycan_b (string): glycan in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | permitted_roots (set): which nodes should be considered as roots; default:["Gal(b1-4)Glc-ol", "Gal(b1-4)GlcNAc-ol"]
-  | min_size (int): length of smallest root in biosynthetic network; default:1
-  | allowed_ptms (set): list of PTMs to consider\n
-  | Returns:
-  | :-
-  | (1) list of edges to connect glycan_a and glycan_b via virtual nodes
-  | (2) dictionary of edge labels detailing difference between two connected nodes"""
+def find_path(glycan_a: str, # First glycan
+             glycan_b: str, # Second glycan
+             graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+             permitted_roots: FrozenSet[str] = permitted_roots, # Allowed root nodes
+             min_size: int = 1, # Minimum root size; default:1
+             allowed_ptms: FrozenSet[str] = allowed_ptms # Set of allowed PTMs
+            ) -> Tuple[List[Tuple[str, str]], Dict[Tuple[str, str], str]]: # (Edge list, Edge labels)
+  "Find virtual node path between two glycans"
   larger_glycan, smaller_glycan = max(glycan_a, glycan_b, key = len), min(glycan_a, glycan_b, key = len)
   # Bridge the distance between a and b by generating biosynthetic precursors
   dist = larger_glycan.count('(') - smaller_glycan.count('(')
@@ -287,21 +228,14 @@ def find_path(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], perm
   return virtual_edges, {el: find_diff(el[0], el[1], graph_dic, allowed_ptms = allowed_ptms) for el in virtual_edges}
 
 
-def find_shortest_path(goal_glycan: str, glycan_list: list[str], graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
-                       min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> tuple[list[tuple[str, str]], dict[tuple[str, str], str]]:
-  """Finds the glycan with the shortest path via virtual nodes to the goal glycan\n
-  | Arguments:
-  | :-
-  | goal_glycan (string): glycan in IUPAC-condensed format
-  | glycan_list (list): list of glycans in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | permitted_roots (set): which nodes should be considered as roots; default:["Gal(b1-4)Glc-ol", "Gal(b1-4)GlcNAc-ol"]
-  | min_size (int): length of smallest root in biosynthetic network; default:1
-  | allowed_ptms (set): list of PTMs to consider\n
-  | Returns:
-  | :-
-  | (1) list of edges of shortest path to connect goal_glycan and glycan via virtual nodes
-  | (2) dictionary of edge labels detailing difference between two connected nodes in shortest path"""
+def find_shortest_path(goal_glycan: str, # Target glycan
+                      glycan_list: List[str], # List of glycans
+                      graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                      permitted_roots: FrozenSet[str] = permitted_roots, # Allowed root nodes
+                      min_size: int = 1, # Minimum root size; default:1
+                      allowed_ptms: FrozenSet[str] = allowed_ptms # Set of allowed PTMs
+                     ) -> Tuple[List[Tuple[str, str]], Dict[Tuple[str, str], str]]: # (Edge list, Edge labels)
+  "Find glycan with shortest virtual path to goal glycan"
   ggraph = safe_index(goal_glycan, graph_dic)
   for glycan in sorted(glycan_list, key = len, reverse = True):
     # For each glycan, check whether it could constitute a precursor (i.e., is it a sub-graph + does it stem from the correct root)
@@ -316,52 +250,33 @@ def find_shortest_path(goal_glycan: str, glycan_list: list[str], graph_dic: dict
   return [], {}
 
 
-def filter_disregard(network: nx.Graph, attr: str = 'diffs', value: str = 'disregard') -> nx.Graph:
-  """Filters out mistaken edges\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network from construct_network
-  | attr (string): edge attribute name; default:'diffs'
-  | value (string): which value of attr to filter out; default:'disregard'\n
-  | Returns:
-  | :-
-  | Returns network without mistaken edges"""
+def filter_disregard(network: nx.Graph, # Biosynthetic network
+                    attr: str = 'diffs', # Edge attribute name
+                    value: str = 'disregard' # Value to filter
+                   ) -> nx.Graph: # Filtered network
+  "Filter out mistaken edges"
   network.remove_edges_from([(u, v) for u, v, data in network.edges(data = True) if data.get(attr) == value])
   return network
 
 
-def stemify_glycan_fast(ggraph_in: nx.Graph, stem_lib: dict[str, str]) -> tuple[str, nx.Graph]:
-  """Stemifies a glycan graph\n
-  | Arguments:
-  | :-
-  | ggraph_in (networkx): glycan graph as a networkx object
-  | stem_lib (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide\n
-  | Returns:
-  | :-
-  | (1) stemified glycan in IUPAC-condensed as a string
-  | (2) stemified glycan graph as a networkx object"""
+def stemify_glycan_fast(ggraph_in: nx.Graph, # Input glycan graph
+                       stem_lib: Dict[str, str] # Modified-to-core monosaccharide mapping
+                      ) -> Tuple[str, nx.Graph]: # (Stemified glycan, Stemified graph)
+  "Stemify glycan graph quickly using precomputed mapping"
   ggraph = deepcopy(ggraph_in)
   nx.set_node_attributes(ggraph, {k: {"string_labels": stem_lib[v]} for k, v in ggraph.nodes(data = "string_labels")})
   return graph_to_string(ggraph), ggraph
 
 
-def find_ptm(glycan: str, glycans: list[str], graph_dic: dict[str, nx.Graph], stem_lib: dict[str, str],
-             allowed_ptms: frozenset[str] = allowed_ptms, ggraphs: list[nx.Graph] | None = None, 
-             suffix: str = '-ol') -> tuple[tuple[str, str], str] | int:
-  """Identifies precursor glycans for a glycan with a PTM\n
-  | Arguments:
-  | :-
-  | glycan (string): glycan with PTM in IUPAC-condensed format
-  | glycans (list): list of glycans in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | stem_lib (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide
-  | allowed_ptms (set): list of PTMs to consider
-  | ggraphs (list): list of precomputed graphs of the glycan list
-  | suffix (string): optional suffix to be added to the stemified glycan; default:'-ol'\n
-  | Returns:
-  | :-
-  | (1) an edge tuple between input glycan and its biosynthetic precusor without PTM
-  | (2) the PTM that is contained in the input glycan"""
+def find_ptm(glycan: str, # Glycan with PTM
+            glycans: List[str], # List of glycans
+            graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+            stem_lib: Dict[str, str], # Modified-to-core monosaccharide mapping
+            allowed_ptms: FrozenSet[str] = allowed_ptms, # Set of allowed PTMs
+            ggraphs: Optional[List[nx.Graph]] = None, # Precomputed glycan graphs
+            suffix: str = '-ol' # Glycan suffix
+           ) -> Union[Tuple[Tuple[str, str], str], int]: # Edge tuple (glycan, precursor) and PTM or 0
+  "Identify precursor glycans for glycan with PTM"
   # Checks which PTM(s) are present
   mod = next((ptm for ptm in allowed_ptms if ptm in glycan), None)
   if mod is None:
@@ -387,20 +302,13 @@ def find_ptm(glycan: str, glycans: list[str], graph_dic: dict[str, nx.Graph], st
     return 0
 
 
-def process_ptm(glycans: list[str], graph_dic: dict[str, nx.Graph], stem_lib: dict[str, str],
-                allowed_ptms: frozenset[str] = allowed_ptms, suffix: str = '-ol') -> tuple[list, list]:
-  """Identifies glycans that contain post-translational modifications and their biosynthetic precursor\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed format
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | stem_lib (dictionary): dictionary of form modified_monosaccharide:core_monosaccharide
-  | allowed_ptms (set): list of PTMs to consider
-  | suffix (string): optional suffix to be added to the stemified glycan; default:'-ol'\n
-  | Returns:
-  | :-
-  | (1) list of edge tuples between input glycans and their biosynthetic precusor without PTM
-  | (2) list of the PTMs that are contained in the input glycans"""
+def process_ptm(glycans: List[str], # List of glycans
+               graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+               stem_lib: Dict[str, str], # Modified-to-core monosaccharide mapping
+               allowed_ptms: FrozenSet[str] = allowed_ptms, # Set of allowed PTMs
+               suffix: str = '-ol' # Glycan suffix
+              ) -> Tuple[List, List]: # (Edge tuples (glycan, precursor), PTM labels)
+  "Find PTM-containing glycans and their precursors"
   # Get glycans with PTMs and convert them to graphs
   ptm_glycans = [glycan for glycan in glycans if any(ptm in glycan for ptm in allowed_ptms)]
   ggraphs = list(map(lambda k: safe_index(k, graph_dic), glycans))
@@ -414,18 +322,12 @@ def process_ptm(glycans: list[str], graph_dic: dict[str, nx.Graph], stem_lib: di
     return [], []
 
 
-def update_network(network_in: nx.Graph, edge_list: list[tuple[str, str]], edge_labels: list[str] | None = None,
-                  node_labels: dict[str, int] | None = None) -> nx.Graph:
-  """Updates a network with new edges and their labels\n
-  | Arguments:
-  | :-
-  | network (networkx object): network that should be modified
-  | edge_list (list): list of edges as node tuples
-  | edge_labels (list): list of edge labels as strings
-  | node_labels (dict): dictionary of form node:0 or 1 depending on whether the node is observed or virtual\n
-  | Returns:
-  | :-
-  | Returns network with added edges"""
+def update_network(network_in: nx.Graph, # Input network
+                  edge_list: List[Tuple[str, str]], # List of edges to add
+                  edge_labels: Optional[List[str]] = None, # Labels for new edges
+                  node_labels: Optional[Dict[str, int]] = None # Node virtual status (0: observed, 1: virtual)
+                 ) -> nx.Graph: # Updated network
+  "Update network with new edges and labels"
   network = network_in.copy()
   network.add_edges_from(edge_list)
   if edge_labels:
@@ -437,34 +339,23 @@ def update_network(network_in: nx.Graph, edge_list: list[tuple[str, str]], edge_
   return network
 
 
-def return_unconnected_to_root(network: nx.Graph, permitted_roots: frozenset[str] = permitted_roots) -> set[str]:
-  """Finds observed nodes that are not connected to the root nodes\n
-  | Arguments:
-  | :-
-  | network (networkx object): network that should be analyzed
-  | permitted_roots (set): which nodes should be considered as roots; default:{"Gal(b1-4)Glc-ol", "Gal(b1-4)GlcNAc-ol"}\n
-  | Returns:
-  | :-
-  | Returns set of nodes that are not connected to the root nodes"""
+def return_unconnected_to_root(network: nx.Graph, # Biosynthetic network
+                              permitted_roots: FrozenSet[str] = permitted_roots # Allowed root nodes
+                             ) -> Set[str]: # Nodes not connected to roots
+  "Find observed nodes not connected to root nodes"
   # Pre-filter nodes that are observed and not in permitted_roots
   candidate_nodes = {node for node, attr in network.nodes(data = True) if attr.get('virtual', 1) == 0 and node not in permitted_roots}
   # For each observed node, check whether it has a path to a root; if not, collect and return the node
   return set(filter(lambda node: not any(nx.has_path(network, node, root) for root in permitted_roots), candidate_nodes))
 
 
-def deorphanize_nodes(network: nx.Graph, graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
-                     min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> nx.Graph:
-  """Finds nodes unconnected to root nodes and tries to connect them\n
-  | Arguments:
-  | :-
-  | network (networkx object): network that should be modified
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | permitted_roots (set): which nodes should be considered as roots; default:["Gal(b1-4)Glc-ol", "Gal(b1-4)GlcNAc-ol"]
-  | min_size (int): length of smallest root in biosynthetic network; default:1
-  | allowed_ptms (set): list of PTMs to consider\n
-  | Returns:
-  | :-
-  | Returns network with deorphanized nodes (if they can be connected to root nodes)"""
+def deorphanize_nodes(network: nx.Graph, # Biosynthetic network
+                     graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                     permitted_roots: FrozenSet[str] = permitted_roots, # Allowed root nodes
+                     min_size: int = 1, # Minimum root size; default:1
+                     allowed_ptms: FrozenSet[str] = allowed_ptms # Set of allowed PTMs
+                    ) -> nx.Graph: # Network with connected nodes
+  "Connect unconnected nodes to root nodes where possible"
   permitted_roots = frozenset({root for root in permitted_roots if root in network.nodes()})
   if not permitted_roots:
     return network.copy()
@@ -496,29 +387,19 @@ def deorphanize_nodes(network: nx.Graph, graph_dic: dict[str, nx.Graph], permitt
   return update_network(network, edges, edge_labels = edge_labels, node_labels = node_labels)
 
 
-def prune_directed_edges(network: nx.DiGraph) -> nx.DiGraph:
-  """Removes edges that go against the direction of biosynthesis\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network with directed edges\n
-  | Returns:
-  | :-
-  | Returns a network with pruned edges that would go in the wrong direction"""
+def prune_directed_edges(network: nx.DiGraph # Directed network
+                       ) -> nx.DiGraph: # Pruned network
+  "Remove edges going against biosynthetic direction"
   edges_to_remove = [(u, v) for u, v in network.edges() if len(u) > len(v)]
   network.remove_edges_from(edges_to_remove)
   return network
 
 
-def deorphanize_edge_labels(network: nx.Graph, graph_dic: dict[str, nx.Graph], allowed_ptms: frozenset[str] = allowed_ptms) -> nx.Graph:
-  """Completes edge labels in newly added edges of a biosynthetic network\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | graph_dic (dict): dictionary of form glycan : glycan-graph
-  | allowed_ptms (set): list of PTMs to consider\n
-  | Returns:
-  | :-
-  | Returns a network with completed edge labels"""
+def deorphanize_edge_labels(network: nx.Graph, # Biosynthetic network
+                          graph_dic: Dict[str, nx.Graph], # Dictionary of glycan:graph mappings
+                          allowed_ptms: FrozenSet[str] = allowed_ptms # Set of allowed PTMs
+                         ) -> nx.Graph: # Network with complete labels
+  "Complete edge labels in newly added edges"
   edge_labels = nx.get_edge_attributes(network, 'diffs')
   unlabeled_edges = [edge for edge in network.edges() if edge not in edge_labels]
   for edge in unlabeled_edges:
@@ -527,14 +408,9 @@ def deorphanize_edge_labels(network: nx.Graph, graph_dic: dict[str, nx.Graph], a
 
 
 @lru_cache(maxsize = None)
-def infer_roots(glycans: frozenset[str]) -> frozenset[str]:
-  """Infers the correct permitted roots, given the glycan class\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed format\n
-  | Returns:
-  | :-
-  | Returns a set of permitted roots"""
+def infer_roots(glycans: FrozenSet[str] # Set of glycans
+               ) -> FrozenSet[str]: # Set of permitted roots
+  "Infer correct permitted roots for glycan class"
   # Free
   if any(k.endswith('-ol') for k in glycans):
     return frozenset({'Gal(b1-4)Glc-ol', 'Gal(b1-4)GlcNAc-ol'})
@@ -554,14 +430,9 @@ def infer_roots(glycans: frozenset[str]) -> frozenset[str]:
     print("Glycan class not detected; depending on the class, glycans should end in -ol, GalNAc, GlcNAc, or 1Cer")
 
 
-def add_high_man_removal(network: nx.Graph) -> nx.Graph:
-  """Considers the process of cutting down high-mannose N-glycans for maturation\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network\n
-  | Returns:
-  | :-
-  | Returns a network with edges going upstream to indicate removal of Man"""
+def add_high_man_removal(network: nx.Graph # Biosynthetic network
+                       ) -> nx.Graph: # Network with high-mannose removal
+  "Add 'reverse' edges for high-mannose N-glycan maturation (i.e., cutting down)"
   edges_to_add = [(target, source, network[source][target])
                     for source, target in network.edges()
                     if target.count('Man') >= 5]
@@ -570,19 +441,13 @@ def add_high_man_removal(network: nx.Graph) -> nx.Graph:
 
 
 @rescue_glycans
-def construct_network(glycans: list[str], allowed_ptms: frozenset[str] = allowed_ptms, edge_type: str = 'monolink',
-                      permitted_roots: frozenset[str] | None = None, abundances: list[float] = []) -> nx.DiGraph:
-  """Construct a glycan biosynthetic network\n
-  | Arguments:
-  | :-
-  | glycans (list): list of glycans in IUPAC-condensed format
-  | allowed_ptms (set): list of PTMs to consider
-  | edge_type (string): indicates whether edges represent monosaccharides ('monosaccharide'), monosaccharide(linkage) ('monolink'), or enzyme catalyzing the reaction ('enzyme'); default:'monolink'
-  | permitted_roots (set): which nodes should be considered as roots; default:will be inferred
-  | abundances (list): optional list of abundances, in the same order as glycans; default:empty list\n
-  | Returns:
-  | :-
-  | Returns a networkx object of the network"""
+def construct_network(glycans: List[str], # List of glycans
+                     allowed_ptms: FrozenSet[str] = allowed_ptms, # Set of allowed PTMs
+                     edge_type: str = 'monolink', # Edge label type: monolink/monosaccharide/enzyme
+                     permitted_roots: Optional[FrozenSet[str]] = None, # Allowed root nodes
+                     abundances: List[float] = [] # Glycan abundances in the same order as glycans; default:empty
+                    ) -> nx.DiGraph: # Biosynthetic network
+  "Construct glycan biosynthetic network"
   glycans = list(set(glycans))
   stem_lib = get_stem_lib(get_lib(glycans))
   if permitted_roots is None:
@@ -673,15 +538,12 @@ def construct_network(glycans: list[str], allowed_ptms: frozenset[str] = allowed
   return filter_disregard(network)
 
 
-def plot_network(network: nx.Graph, plot_format: str = 'pydot2', 
-                edge_label_draw: bool = True, lfc_dict: dict[str, float] | None = None) -> None:
-  """Visualizes biosynthetic network\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | plot_format (string): how to layout network, either 'pydot2', 'kamada_kawai', or 'spring'; default:'pydot2'
-  | edge_label_draw (bool): draws edge labels if True; default:True
-  | lfc_dict (dict): dictionary of enzyme:log2-fold-change to scale edge width; default:None\n"""
+def plot_network(network: nx.Graph, # Biosynthetic network
+                plot_format: str = 'pydot2', # Layout type: pydot2/kamada_kawai/spring
+                edge_label_draw: bool = True, # Whether to draw edge labels
+                lfc_dict: Optional[Dict[str, float]] = None # Enzyme:log2FC mapping for edge width
+               ) -> None: # Displays plot
+  "Visualize biosynthetic network"
   try:
     mpld3.enable_notebook()
   except:
@@ -730,15 +592,10 @@ def plot_network(network: nx.Graph, plot_format: str = 'pydot2',
   mpld3.plugins.connect(fig, tooltip)
 
 
-def network_alignment(network_a: nx.Graph, network_b: nx.Graph) -> nx.Graph:
-  """Combines two networks into a new network\n
-  | Arguments:
-  | :-
-  | network_a (networkx object): biosynthetic network from construct_network
-  | network_b (networkx object): biosynthetic network from construct_network\n
-  | Returns:
-  | :-
-  | Returns combined network as a networkx object (brown: shared, blue: only in a, orange: only in b)"""
+def network_alignment(network_a: nx.Graph, # First network
+                     network_b: nx.Graph # Second network
+                    ) -> nx.Graph: # Combined network
+  "Combine two networks into one with color coding (brown: shared, blue: only in a, orange: only in b)"""
   U = nx.Graph()
   network_a_nodes = set(network_a.nodes)
   network_b_nodes = set(network_b.nodes)
@@ -761,23 +618,14 @@ def network_alignment(network_a: nx.Graph, network_b: nx.Graph) -> nx.Graph:
   return U
 
 
-def infer_virtual_nodes(network_a: nx.Graph, network_b: nx.Graph,
-                       combined: nx.Graph | None = None) -> tuple[tuple[list[str], list[str]], tuple[list[str], list[str]]]:
-  """Identifies virtual nodes that have been observed in other species\n
-  | Arguments:
-  | :-
-  | network_a (networkx object): biosynthetic network from construct_network
-  | network_b (networkx object): biosynthetic network from construct_network
-  | combined (networkx object): merged network of network_a and network_b from network_alignment; default:None\n
-  | Returns:
-  | :-
-  | (1) tuple of (virtual nodes of network_a observed in network_b, virtual nodes occurring in both network_a and network_b)
-  | (2) tuple of (virtual nodes of network_b observed in network_a, virtual nodes occurring in both network_a and network_b)"""
+def infer_virtual_nodes(network_a: nx.Graph, # First network
+                       network_b: nx.Graph, # Second network
+                       combined: Optional[nx.Graph] = None # Pre-merged network from network_alignment
+                      ) -> Tuple[Tuple[List[str], List[str]], Tuple[List[str], List[str]]]: # ((a-virtuals in b, shared), (b-virtuals in a, shared))
+  "Identify virtual nodes observed in other species"
   # Perform network alignment if not provided
   if combined is None:
     combined = network_alignment(network_a, network_b)
-  a_nodes = set(network_a.nodes())
-  b_nodes = set(network_b.nodes())
   # Find virtual nodes in network_a that are observed in network_b and vice versa
   virtual_a = {k for k, v in network_a.nodes(data = True) if v.get('virtual', 0) == 1}
   virtual_b = {k for k, v in network_b.nodes(data = True) if v.get('virtual', 0) == 1}
@@ -789,17 +637,12 @@ def infer_virtual_nodes(network_a: nx.Graph, network_b: nx.Graph,
   return (list(inferred_a), list(supported_a)), (list(inferred_b), list(supported_b))
 
 
-def infer_network(network: nx.Graph, network_species: str, species_list: list[str], network_dic: dict[str, nx.Graph]) -> nx.Graph:
-  """Replaces virtual nodes if they are observed in other species\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network that should be inferred
-  | network_species (string): species from which the network stems
-  | species_list (list): list of species to compare network to
-  | network_dic (dict): dictionary of form species name : biosynthetic network (gained from construct_network)\n
-  | Returns:
-  | :-
-  | Returns network with filled in virtual nodes"""
+def infer_network(network: nx.Graph, # Network to infer
+                 network_species: str, # Source species
+                 species_list: List[str], # Species to compare against
+                 network_dic: Dict[str, nx.Graph] # Species:network mapping
+                ) -> nx.Graph: # Network with inferred nodes
+  "Replace virtual nodes observed in other species"
   inferences = set()
   # For each species, try to identify observed nodes matching virtual nodes in input network
   for k in species_list:
@@ -815,30 +658,19 @@ def infer_network(network: nx.Graph, network_species: str, species_list: list[st
   return network2
 
 
-def retrieve_inferred_nodes(network: nx.Graph, species: str | None = None) -> list[str] | dict[str, list[str]]:
-  """Returns the inferred virtual nodes of a network that has been used with infer_network\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network with inferred virtual nodes
-  | species (string): species from which the network stems (only relevant if multiple species in network); default:None\n
-  | Returns:
-  | :-
-  | Returns inferred nodes as list or dictionary (if species argument is used)"""
+def retrieve_inferred_nodes(network: nx.Graph, # Network with inferred nodes
+                          species: Optional[str] = None # Source species if multiple
+                         ) -> Union[List[str], Dict[str, List[str]]]: # Inferred nodes list or dict
+  "Get inferred virtual nodes from network"
   inferred_nodes = [node for node, value in nx.get_node_attributes(network, 'virtual').items() if value == 2]
   return {species: inferred_nodes} if species is not None else inferred_nodes
 
 
-def export_network(network: nx.Graph, filepath: str, other_node_attributes: list[str] | None = None) -> None:
-  """Converts NetworkX network into files usable, e.g., by Cytoscape or Gephi\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | filepath (string): should describe a valid path + file name prefix, will be appended by file description and type
-  | other_node_attributes (list): string names of node attributes that should also be extracted; default:[]\n
-  | Returns:
-  | :-
-  | (1) saves a .csv dataframe containing the edge list and edge labels
-  | (2) saves a .csv dataframe containing node IDs and labels"""
+def export_network(network: nx.Graph, # Biosynthetic network
+                  filepath: str, # Output path prefix, will be appended by file description and type
+                  other_node_attributes: Optional[List[str]] = None # Additional attributes for extraction
+                 ) -> None: # Saves network files (edge list/labels + node IDs and labels)
+  "Export network to Cytoscape/Gephi compatible files"
   # Generate edge_list
   if network.edges():
     edge_list = pd.DataFrame([(u, v, d.get('diffs', '')) for u, v, d in network.edges(data = True)], columns = ['Source', 'Target', 'Label'])
@@ -854,39 +686,27 @@ def export_network(network: nx.Graph, filepath: str, other_node_attributes: list
   pd.DataFrame(node_labels_dict).to_csv(f"{filepath}_node_labels.csv", index = False)
 
 
-def monolink_to_glycoenzyme(edge_label: str, df: pd.DataFrame, enzyme_column: str = 'glycoenzyme',
-                           monolink_column: str = 'monolink', mode: str = 'condensed') -> str:
-  """Replaces monosaccharide(linkage) edge label by the name of the enzyme responsible for its synthesis\n
-  | Arguments:
-  | :-
-  | edge_label (str): 'monolink' edge label
-  | df (dataframe): dataframe containing the glycoenzymes and their corresponding 'monolink'
-  | enzyme_column (str): name of the column in df that indicates the enzyme; default:'glycoenzyme'
-  | monolink_column (str): name of the column in df that indicates the 'monolink'; default:'monolink'
-  | mode (str): determine if all glycoenzymes must be represented (full) or if only glycoenzyme families are shown (condensed); default:'condensed'\n
-  | Returns:
-  | :-
-  | Returns a new edge label corresponding to the enzyme that catalyzes this reaction"""
+def monolink_to_glycoenzyme(edge_label: str, # Monolink edge label
+                           df: pd.DataFrame, # Glycoenzyme mapping data
+                           enzyme_column: str = 'glycoenzyme', # Enzyme column name
+                           monolink_column: str = 'monolink', # Monolink column name
+                           mode: str = 'condensed' # Output mode: condensed/full
+                          ) -> str: # Enzyme label
+  "Convert monosaccharide(linkage) edge label to enzyme name responsible for its synthesis"
   if mode == 'condensed':
     enzyme_column = 'glycoclass'
   new_edge_label = df.loc[df[monolink_column] == edge_label, enzyme_column].unique()
   return '_'.join(new_edge_label) if new_edge_label.size else edge_label
 
 
-def choose_path(diamond: dict[int, str], species_list: list[str], network_dic: dict[str, nx.Graph], threshold: float = 0.,
-                nb_intermediates: int = 2, mode: str = 'presence') -> dict[str, float]:
-  """Given a shape such as diamonds in biosynthetic networks (A->B,A->C,B->D,C->D), which path is taken from A to D?\n
-  | Arguments:
-  | :-
-  | diamond (dict): dictionary of form position-in-diamond : glycan-string, describing the diamond
-  | species_list (list): list of species to compare network to
-  | network_dic (dict): dictionary of form species name : biosynthetic network (gained from construct_network)
-  | threshold (float): everything below or equal to that threshold will be cut; default:0.
-  | nb_intermediates (int): number of intermediate nodes expected in a network motif to extract; has to be a multiple of 2 (2: diamond, 4: hexagon,...)
-  | mode (string): whether to analyze for "presence" or "abundance" of intermediates; default:"presence"\n
-  | Returns:
-  | :-
-  | Returns dictionary of each intermediary path and its experimental support (0-1) across species"""
+def choose_path(diamond: Dict[int, str], # Diamond node positions mapping to glycans
+               species_list: List[str], # Species to compare against
+               network_dic: Dict[str, nx.Graph], # Species:network mapping
+               threshold: float = 0.0, # Cutoff threshold
+               nb_intermediates: int = 2, # Number of intermediate nodes; has to be a multiple of 2
+               mode: str = 'presence' # Analysis mode: presence/abundance
+              ) -> Dict[str, float]: # Path support scores
+  "Determine preferred path through network motif across species/conditions"
   graph_dic = {k: glycan_to_nxGraph(k) for k in diamond.values()}
   # Construct the diamond between source and target node
   network, _ = create_adjacency_matrix(list(diamond.values()), graph_dic)
@@ -915,16 +735,11 @@ def choose_path(diamond: dict[int, str], species_list: list[str], network_dic: d
   return {k[0]: v for k, v in alts.items()} if nb_intermediates == 2 else alts
 
 
-def find_diamonds(network: nx.Graph, nb_intermediates: int = 2, mode: str = 'presence') -> list[dict[int, str]]:
-  """Automatically extracts shapes such as diamonds (A->B,A->C,B->D,C->D) from biosynthetic networks\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | nb_intermediates (int): number of intermediate nodes expected in a network motif to extract; has to be a multiple of 2 (2: diamond, 4: hexagon,...)
-  | mode (string): whether to analyze for "presence" or "abundance" of intermediates; default:"presence"\n
-  | Returns:
-  | :-
-  | Returns list of dictionaries, with each dictionary a network motif in the form of position in the motif : glycan"""
+def find_diamonds(network: nx.Graph, # Biosynthetic network
+                 nb_intermediates: int = 2, # Number of intermediate nodes; has to be a multiple of 2
+                 mode: str = 'presence' # Analysis mode: presence/abundance
+                ) -> List[Dict[int, str]]: # List of diamond motifs as diamond node positions mapping to glycans
+  "Find diamond-like motifs (A->B,A->C,B->D,C->D) in biosynthetic network"
   if nb_intermediates % 2 > 0:
     print("nb_intermediates has to be a multiple of 2; please re-try.")
     return []
@@ -964,20 +779,14 @@ def find_diamonds(network: nx.Graph, nb_intermediates: int = 2, mode: str = 'pre
   return final_matchings
 
 
-def trace_diamonds(network: nx.Graph, species_list: list[str], network_dic: dict[str, nx.Graph], threshold: float = 0.,
-                  nb_intermediates: int = 2, mode: str = 'presence') -> pd.DataFrame:
-  """Extracts diamond-shape motifs from biosynthetic networks (A->B,A->C,B->D,C->D) and uses evolutionary information to determine which path is taken from A to D\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | species_list (list): list of species to compare network to
-  | network_dic (dict): dictionary of form species name : biosynthetic network (gained from construct_network)
-  | threshold (float): everything below or equal to that threshold will be cut; default:0.
-  | nb_intermediates (int): number of intermediate nodes expected in a network motif to extract; has to be a multiple of 2 (2: diamond, 4: hexagon,...)
-  | mode (string): whether to analyze for "presence" or "abundance" of intermediates; default:"presence"\n
-  | Returns:
-  | :-
-  | Returns dataframe of each intermediary glycan and its proportion (0-1) of how often it has been experimentally observed in this path (or average abundance if mode = abundance)"""
+def trace_diamonds(network: nx.Graph, # Biosynthetic network
+                  species_list: List[str], # Species to compare against
+                  network_dic: Dict[str, nx.Graph], # Species:network mapping
+                  threshold: float = 0.0, # Cutoff threshold
+                  nb_intermediates: int = 2, # Number of intermediate nodes; has to be a multiple of 2
+                  mode: str = 'presence' # Analysis mode: presence/abundance
+                 ) -> pd.DataFrame: # Path analysis results, with proportion (0-1) of how often glycan has been experimentally observed in this path (or average abundance)
+  "Analyze diamond motif (A->B,A->C,B->D,C->D) path preferences using evolutionary data"
   # Get the diamonds
   matchings_list = find_diamonds(network, nb_intermediates = nb_intermediates, mode = mode)
   # Calculate the path probabilities
@@ -988,16 +797,11 @@ def trace_diamonds(network: nx.Graph, species_list: list[str], network_dic: dict
   return df_out
 
 
-def prune_network(network: nx.Graph, node_attr: str = 'abundance', threshold: float = 0.) -> nx.Graph:
-  """Pruning a network by dismissing unlikely virtual paths\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network such as from construct_network
-  | node_attr (string): which (numerical) node attribute to use for pruning; default:'abundance'
-  | threshold (float): everything below or equal to that threshold will be cut; default:0.\n
-  | Returns:
-  | :-
-  | Returns pruned network"""
+def prune_network(network: nx.Graph, # Biosynthetic network
+                 node_attr: str = 'abundance', # Node attribute to use for pruning
+                 threshold: float = 0.0 # Cutoff threshold
+                ) -> nx.Graph: # Pruned network
+  "Remove unlikely virtual paths from network"
   network_out = deepcopy(network)
   node_attrs = nx.get_node_attributes(network_out, node_attr)
   # Prune nodes lower in attribute than threshold
@@ -1013,21 +817,15 @@ def prune_network(network: nx.Graph, node_attr: str = 'abundance', threshold: fl
   return network_out
 
 
-def evoprune_network(network: nx.Graph, network_dic: dict[str, nx.Graph] | None = None, species_list: list[str] | None = None,
-                     node_attr: str = 'abundance', threshold: float = 0.01, nb_intermediates: int = 2, mode: str = 'presence') -> nx.Graph:
-  """Given a biosynthetic network, this function uses evolutionary relationships to prune impossible paths\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | network_dic (dict): dictionary of form species name : biosynthetic network (gained from construct_network); default:pre-computed milk networks
-  | species_list (list): list of species to compare network to; default:species from pre-computed milk networks
-  | node_attr (string): which (numerical) node attribute to use for pruning; default:'abundance'
-  | threshold (float): everything below or equal to that threshold will be cut; default:0.01
-  | nb_intermediates (int): number of intermediate nodes expected in a network motif to extract; has to be a multiple of 2 (2: diamond, 4: hexagon,...)
-  | mode (string): whether to analyze for "presence" or "abundance" of intermediates; default:"presence"\n
-  | Returns:
-  | :-
-  | Returns pruned network (with virtual node probability as a new node attribute)"""
+def evoprune_network(network: nx.Graph, # Biosynthetic network
+                    network_dic: Optional[Dict[str, nx.Graph]] = None, # Species:network mapping
+                    species_list: Optional[List[str]] = None, # Species to compare against
+                    node_attr: str = 'abundance', # Node attribute to use for pruning
+                    threshold: float = 0.01, # Cutoff threshold
+                    nb_intermediates: int = 2, # Number of intermediate nodes; has to be a multiple of 2
+                    mode: str = 'presence' # Analysis mode: presence/abundance
+                   ) -> nx.Graph: # Evolutionarily pruned network (with virtual node probability as a new node attribute)
+  "Prune network using evolutionary path preferences"
   if network_dic is None:
     network_dic = pickle.load(open(data_path, 'rb'))
   if species_list is None:
@@ -1042,24 +840,17 @@ def evoprune_network(network: nx.Graph, network_dic: dict[str, nx.Graph] | None 
   return prune_network(network_out, node_attr = node_attr, threshold = threshold*100)
 
 
-def highlight_network(network: nx.Graph, highlight: str, motif: str | None = None, abundance_df: pd.DataFrame | None = None,
-                      glycan_col: str = 'glycan', intensity_col: str = 'rel_intensity', conservation_df: pd.DataFrame | None = None,
-                      network_dic: dict[str, nx.Graph] | None = None, species: str | None = None) -> nx.Graph:
-  """Highlights a certain attribute in the network that will be visible when using plot_network\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | highlight (string): which attribute to highlight (choices are 'motif' for glycan motifs, 'abundance' for glycan abundances, 'conservation' for glycan conservation, 'species' for highlighting 1 species in multi-network)
-  | motif (string): highlight=motif; which motif to highlight (absence/presence, in violet/green); default:None
-  | abundance_df (dataframe): highlight=abundance; dataframe containing glycans and their relative intensity
-  | glycan_col (string): highlight=abundance; column name of the glycans in abundance_df
-  | intensity_col (string): highlight=abundance; column name of the relative intensities in abundance_df
-  | conservation_df (dataframe): highlight=conservation; dataframe containing glycans from different species
-  | network_dic (dict): highlight=conservation/species; dictionary of form species name : biosynthetic network (gained from construct_network); default:pre-computed milk networks
-  | species (string): highlight=species; which species to highlight in a multi-species network\n
-  | Returns:
-  | :-
-  | Returns a network with the additional 'origin' (motif/species) or 'abundance' (abundance/conservation) node attribute storing the highlight"""
+def highlight_network(network: nx.Graph, # Biosynthetic network
+                     highlight: str, # What to highlight: motif/species/abundance/conservation
+                     motif: Optional[str] = None, # Motif to highlight; highlight=motif
+                     abundance_df: Optional[pd.DataFrame] = None, # Glycan abundance data; highlight=abundance
+                     glycan_col: str = 'glycan', # Glycan column name; highlight=abundance
+                     intensity_col: str = 'rel_intensity', # Intensity column name; highlight=abundance
+                     conservation_df: Optional[pd.DataFrame] = None, # Species-glycan data; highlight=conservation
+                     network_dic: Optional[Dict[str, nx.Graph]] = None, # Species:network mapping; highlight=conservation/species
+                     species: Optional[str] = None # Species to highlight; highlight=species
+                    ) -> nx.Graph: # Network with highlight attributes ('origin' (motif/species) or 'abundance' (abundance/conservation) node attribute)
+  "Add visual highlighting to network nodes, to be used in plot_network"
   if network_dic is None:
     network_dic = pickle.load(open(data_path, 'rb'))
   # Determine highlight validity
@@ -1108,16 +899,11 @@ def highlight_network(network: nx.Graph, highlight: str, motif: str | None = Non
   return network_out
 
 
-def get_edge_weight_by_abundance(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol", root_default: float = 10.0) -> nx.Graph:
-  """Estimate reaction capacity by the relative abundance of source and sink\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | root (string): root node of network; default:"Gal(b1-4)Glc-ol"
-  | root_default (float): dummy abundance value of root; default:10.0\n
-  | Returns:
-  | :-
-  | Returns a network in which the edge attribute 'capacity' has been estimated"""
+def get_edge_weight_by_abundance(network: nx.Graph, # Biosynthetic network
+                               root: str = "Gal(b1-4)Glc-ol", # Root node
+                               root_default: float = 10.0 # Root abundance
+                              ) -> nx.Graph: # Network with edge capacities
+  "Estimate reaction capacity (edge attribute) from node abundances"
   abundance_dict = nx.get_node_attributes(network, 'abundance')
   if abundance_dict.get(root, 1) < 0.1:
     abundance_dict[root] = root_default
@@ -1128,17 +914,12 @@ def get_edge_weight_by_abundance(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol
   return network
 
 
-def estimate_weights(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol", root_default: float = 10, min_default: float = 0.001) -> nx.Graph:
-  """Estimate reaction capacity of edges and missing relative abundances\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | root (string): root node of network; default:"Gal(b1-4)Glc-ol"
-  | root_default (float): dummy abundance value of root; default:10.0
-  | min_default (float): a small default value if no non-zero neighboring weights; default: 0.001\n
-  | Returns:
-  | :-
-  | Returns a network in which the edge attribute 'capacity' and missing abundances have been estimated"""
+def estimate_weights(network: nx.Graph, # Biosynthetic network
+                    root: str = "Gal(b1-4)Glc-ol", # Root node
+                    root_default: float = 10, # Root abundance
+                    min_default: float = 0.001 # Minimum weight
+                   ) -> nx.Graph: # Network with estimated weights
+  "Estimate reaction capacity (edge attribute) and missing abundances"
   net_estimated = get_edge_weight_by_abundance(network, root = root, root_default = root_default)
   # Function to estimate weight based on neighboring edges
   def estimate_weight(node):
@@ -1154,17 +935,11 @@ def estimate_weights(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol", root_defa
   return net_estimated
 
 
-def get_maximum_flow(network: nx.Graph, source: str = "Gal(b1-4)Glc-ol", 
-                    sinks: list[str] | None = None) -> dict[str, dict[str, float | dict[str, dict[str, float]]]]:
-  """Estimate maximum flow and flow paths between source and sinks\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | source (string): usually the root node of network; default:"Gal(b1-4)Glc-ol"
-  | sinks (list of strings): specified sinks to estimate flow for; default:all terminal nodes\n
-  | Returns:
-  | :-
-  | Returns a dictionary of type sink : {maximum flow value, flow path dictionary}"""
+def get_maximum_flow(network: nx.Graph, # Biosynthetic network
+                    source: str = "Gal(b1-4)Glc-ol", # Source node
+                    sinks: Optional[List[str]] = None # Target nodes; default:all terminal nodes
+                   ) -> Dict[str, Dict[str, Union[float, Dict[str, Dict[str, float]]]]]: # Flow results; sink: {maximum flow value, flow path dictionary}
+  "Estimate maximum flow and flow paths between source and sinks"
   if sinks is None:
     sinks = [node for node, out_degree in network.out_degree() if out_degree == 0 and nx.has_path(network, source, node)]
   # Dictionary to store flow values and paths for each sink
@@ -1185,23 +960,16 @@ def get_maximum_flow(network: nx.Graph, source: str = "Gal(b1-4)Glc-ol",
   return flow_results
 
 
-def get_max_flow_path(network: nx.Graph, flow_dict: dict[str, dict[str, float]], 
-                     sink: str, source: str = "Gal(b1-4)Glc-ol") -> list[tuple[str, str]]:
-  """Get the actual path between source and sink that gave rise to the maximum flow value\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | flow_dict (dict): dictionary of type source : {sink : flow} as returned by get_maximum_flow
-  | sink (string): specified sink to retrieve maximum flow path
-  | source (string): usually the root node of network; default:"Gal(b1-4)Glc-ol"\n
-  | Returns:
-  | :-
-  | Returns a list of (source, sink) tuples describing the maximum flow path"""
+def get_max_flow_path(network: nx.Graph, # Biosynthetic network
+                     flow_dict: Dict[str, Dict[str, float]], # Flow dictionary as returned by get_maximum_flow
+                     sink: str, # Target node
+                     source: str = "Gal(b1-4)Glc-ol" # Source node
+                    ) -> List[Tuple[str, str]]: # Path edge list
+  "Get path giving maximum flow value"
   path = []
   current_node = source
   abundance_dict = nx.get_node_attributes(network, 'abundance')
   while current_node != sink:
-    max_metric = 0
     next_node = max(network.neighbors(current_node),
             key = lambda neighbor: flow_dict[current_node][neighbor] * max(abundance_dict.get(neighbor, 0), 0.1),
             default = None)
@@ -1212,18 +980,11 @@ def get_max_flow_path(network: nx.Graph, flow_dict: dict[str, dict[str, float]],
   return path
 
 
-def get_reaction_flow(network: nx.Graph, res: dict[str, dict[str, float]], 
-                     aggregate: str | None = None) -> dict[str, list[float]] | dict[str, float]:
-  """Get the aggregated flows for a type of reaction across entire network\n
-  | Arguments:
-  | :-
-  | network (networkx object): biosynthetic network, returned from construct_network
-  | res (dict): dictionary of type sink : {maximum flow value, flow path dictionary} as returned by get_maximum_flow
-  | aggregate (string): if reaction flow values should be aggregated, options are "sum" and "mean"; default:None\n
-  | Returns:
-  | :-
-  | Returns a dictionary of form reaction : flow(s)
-  """
+def get_reaction_flow(network: nx.Graph, # Biosynthetic network
+                     res: Dict[str, Dict[str, float]], # Flow results as returned by get_maximum_flow
+                     aggregate: Optional[str] = None # Aggregation: sum/mean/None
+                    ) -> Union[Dict[str, List[float]], Dict[str, float]]: # Reaction flows (reaction: flow)
+  "Get aggregated flows by reaction type"
   # Aggregate flow values by reaction type
   reaction_flows = defaultdict(list)
   for sink_data in res.values():
@@ -1237,24 +998,15 @@ def get_reaction_flow(network: nx.Graph, res: dict[str, dict[str, float]],
   return reaction_flows
 
 
-def get_differential_biosynthesis(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int] | None = None, 
-                                analysis: str = "reaction", paired: bool = False, longitudinal: bool = False, 
-                                id_column: str = "ID") -> pd.DataFrame:
-  """Compares biosynthetic patterns between glycomes of two conditions or across multiple time points\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe containing glycan sequences and relative abundances [or filepath to .csv]
-  | group1 (list): list of column indices/names for first group of samples (or time points in longitudinal analysis)
-  | group2 (list): list of column indices/names for second group of samples (ignored in longitudinal analysis)
-  | analysis (string): type of analysis to perform on networks, "reaction" or "flow"; default: "reaction"
-  | paired (bool): whether samples are paired or not; default: False
-  | longitudinal (bool): whether to perform longitudinal analysis; default: False
-  | id_column (str): name of the column containing sample IDs for longitudinal analysis in the ID-style of participant_time_replicate; default: "ID"\n
-  | Returns:
-  | :-
-  | For binary comparison: A dataframe with differential flow features and statistics
-  | For longitudinal analysis: A dataframe with reaction changes over time"""
-
+def get_differential_biosynthesis(df: Union[pd.DataFrame, str], # Glycan abundance data (first column: glycan sequences)
+                                group1: List[Union[str, int]], # First group column indices/names (or time points in longitudinal analysis)
+                                group2: Optional[List[Union[str, int]]] = None, # Second group column indices/names (or time points in longitudinal analysis)
+                                analysis: str = "reaction", # Type: reaction/flow
+                                paired: bool = False, # Whether samples are paired
+                                longitudinal: bool = False, # Whether to do perform longitudinal analysis
+                                id_column: str = "ID" # Sample ID column for longitudinal analysis in the ID-style of participant_time_replicate
+                               ) -> pd.DataFrame: # Differential analysis results (differential flow features and statistics OR reaction changes over time
+  "Compare biosynthetic patterns between conditions/timepoints"
   if longitudinal:
     assert id_column is not None, "id_column must be specified for longitudinal analysis"
     assert group2 is None, "group2 should not be specified for longitudinal analysis"
@@ -1385,16 +1137,11 @@ def get_differential_biosynthesis(df: pd.DataFrame | str, group1: list[str | int
   return out.dropna().sort_values(by = 'p-val')
 
 
-def extend_glycans(glycans: list[str] | set[str], reactions: list[str] | set[str], allowed_disaccharides: set[str] | None = None) -> set[str]:
-  """Given a set of reactions, tries to extend observed glycans\n
-  | Arguments:
-  | :-
-  | glycans (list or set): glycans in IUPAC-condensed format
-  | reactions (list or set): reactions in the form of 'Fuc(a1-3)'
-  | allowed_disaccharides (set): disaccharides that are permitted when creating possible glycans; default:not used\n
-  | Returns:
-  | :-
-  | Returns set of new glycans that have been created with the provided reactions"""
+def extend_glycans(glycans: Union[List[str], Set[str]], # Glycans to extend
+                  reactions: Union[List[str], Set[str]], # Reactions to apply, in the form of 'Fuc(a1-3)'
+                  allowed_disaccharides: Optional[Set[str]] = None # Valid disaccharides when creating possible glycans
+                 ) -> Set[str]: # New glycans
+  "Extend glycans using provided reactions"
   new_glycans = set()
   for r in reactions:
     temp_glycans = [f'{{{r}}}{g}' for g in glycans]
@@ -1403,17 +1150,11 @@ def extend_glycans(glycans: list[str] | set[str], reactions: list[str] | set[str
   return new_glycans
 
 
-def edges_for_extension(leaf_glycans: set[str], new_glycans: set[str],
-                       graphs: dict[str, nx.Graph]) -> tuple[list[tuple[str, str]], list[str]]:
-  """Given leaf nodes and their extensions, creates the corresponding edges and edge labels\n
-  | Arguments:
-  | :-
-  | leaf_glycans (set): set of glycans that are leaf nodes in network
-  | new_glycans (set): set of glycans that have been produced beyond leaf nodes
-  | graphs (dict): dictionary of glycan : glycan graph\n
-  | Returns:
-  | :-
-  | Returns new edges and edge labels that connect leaf_glycans and new_glycans"""
+def edges_for_extension(leaf_glycans: Set[str], # Terminal glycans in a network
+                       new_glycans: Set[str], # Extended glycans
+                       graphs: Dict[str, nx.Graph] # Glycan:graph mapping
+                      ) -> Tuple[List[Tuple[str, str]], List[str]]: # (New edges, Labels)
+  "Create edges connecting leaf and extended glycans"
   new_edges, new_edge_labels = [], []
   new_glycans = list(new_glycans)
   leaf_graphs = {k: safe_index(k, graphs) for k in leaf_glycans}
@@ -1429,15 +1170,10 @@ def edges_for_extension(leaf_glycans: set[str], new_glycans: set[str],
   return new_edges, new_edge_labels
 
 
-def choose_leaves_to_extend(leaf_glycans: set[str], target_composition: dict[str, int]) -> set[str]:
-  """Given a target composition to be reached, pick the best one or more leaf nodes to extend\n
-  | Arguments:
-  | :-
-  | leaf_glycans (set): set of leaf nodes glycans as strings in IUPAC-condensed
-  | target_composition (dict): composition of type {"HexNAc": 2, "Hex": 9} that's the target for extension\n
-  | Returns:
-  | :-
-  | Returns set of leaf nodes to extend"""
+def choose_leaves_to_extend(leaf_glycans: Set[str], # Terminal glycans in a network
+                          target_composition: Dict[str, int] # Target composition of type {"HexNAc": 2, "Hex": 9}
+                         ) -> Set[str]: # Leaf nodes to extend
+  "Choose best leaf nodes to extend toward target"
   target_comp = Counter(target_composition)
 
   def score_glycan(glycan):
@@ -1453,18 +1189,12 @@ def choose_leaves_to_extend(leaf_glycans: set[str], target_composition: dict[str
   return {glycan for glycan, score in scored_glycans if score == min_score}
 
 
-def extend_network(network: nx.Graph, steps: int = 1, to_extend: str | dict[str, int] | list[str] = "all",
-                  strict_context: bool = False) -> tuple[nx.Graph, set[str]]:
-  """Given a biosynthetic network, tries to extend it in a physiological manner\n
-  | Arguments:
-  | :-
-  | network (networkx): glycan biosynthetic network as returned by construct_network
-  | steps (int): how many biosynthetic steps to extend the network
-  | to_extend (string/dict/list): which leaves to extend (default is "all"), a glycan as a string indicates a specific leaf node to extend, a dict indicates a target composition to be reached from the best leaf
-  | strict_context (bool): whether to infer permitted sequence contexts for extension from database (False) or only from network (True); default:False\n
-  | Returns:
-  | :-
-  | Returns updated network and a list of added glycans"""
+def extend_network(network: nx.Graph, # Biosynthetic network
+                  steps: int = 1, # Number of extension steps; default:1
+                  to_extend: Union[str, Dict[str, int], List[str]] = "all", # Nodes to extend (all, specific leaf node, target composition)
+                  strict_context: bool = False # Whether to use network only to derive allowed reaction products; default:False
+                 ) -> Tuple[nx.Graph, Set[str]]: # (Extended network, New glycans)
+  "Extend biosynthetic network physiologically"
   graphs = {}
   new_glycans = set()
   classy = get_class(next(iter(network.nodes())))

--- a/glycowork/network/biosynthesis.py
+++ b/glycowork/network/biosynthesis.py
@@ -38,7 +38,7 @@ allowed_ptms = frozenset({'OS', '3S', '6S', 'OP', '1P', '3P', '6P', 'OAc', '4Ac'
 
 
 @lru_cache(maxsize = None)
-def safe_compare(g1, g2):
+def safe_compare(g1: nx.Graph, g2: nx.Graph) -> bool:
   """Compare_glycans with try/except error catch\n
   | Arguments:
   | :-
@@ -53,7 +53,7 @@ def safe_compare(g1, g2):
     return False
 
 
-def safe_index(glycan, graph_dic):
+def safe_index(glycan: str, graph_dic: dict[str, nx.Graph]) -> nx.Graph:
   """Retrieves glycan graph and if not present in graph_dic it will freshly calculate\n
   | Arguments:
   | :-
@@ -65,7 +65,7 @@ def safe_index(glycan, graph_dic):
   return graph_dic.setdefault(glycan, glycan_to_nxGraph(glycan))
 
 
-def get_neighbors(ggraph, glycans, graphs, min_size = 1):
+def get_neighbors(ggraph: nx.Graph, glycans: list[str], graphs: list[nx.Graph], min_size: int = 1) -> tuple[list[str], list[list[int]]]:
   """Find (observed) biosynthetic precursors of a glycan\n
   | Arguments:
   | :-
@@ -89,7 +89,7 @@ def get_neighbors(ggraph, glycans, graphs, min_size = 1):
 
 
 @lru_cache(maxsize = None)
-def create_neighbors(ggraph, min_size = 1):
+def create_neighbors(ggraph: nx.Graph, min_size: int = 1) -> list[nx.Graph]:
   """Creates biosynthetic precursor glycans\n
   | Arguments:
   | :-
@@ -115,7 +115,7 @@ def create_neighbors(ggraph, min_size = 1):
     ]
 
 
-def get_virtual_nodes(glycan, graph_dic, min_size = 1):
+def get_virtual_nodes(glycan: str, graph_dic: dict[str, nx.Graph], min_size: int = 1) -> tuple[list[nx.Graph], list[str]]:
   """Find unobserved biosynthetic precursors of a glycan\n
   | Arguments:
   | :-
@@ -138,7 +138,7 @@ def get_virtual_nodes(glycan, graph_dic, min_size = 1):
   return ggraph_nb, ggraph_nb_t2
 
 
-def find_diff(glycan_a, glycan_b, graph_dic, allowed_ptms = allowed_ptms):
+def find_diff(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], allowed_ptms: frozenset[str] = allowed_ptms) -> str:
   """Finds the subgraph that differs between glycans and returns it, will only work if the differing subgraph is connected\n
   | Arguments:
   | :-
@@ -163,7 +163,7 @@ def find_diff(glycan_a, glycan_b, graph_dic, allowed_ptms = allowed_ptms):
   return 'disregard'
 
 
-def find_shared_virtuals(glycan_a, glycan_b, graph_dic, min_size = 1):
+def find_shared_virtuals(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], min_size: int = 1) -> list[tuple[str, str]]:
   """Finds virtual nodes that are shared between two glycans (i.e., that connect these two glycans)\n
   | Arguments:
   | :-
@@ -188,7 +188,7 @@ def find_shared_virtuals(glycan_a, glycan_b, graph_dic, min_size = 1):
   return list(out)
 
 
-def adjacencyMatrix_to_network(adjacency_matrix):
+def adjacencyMatrix_to_network(adjacency_matrix: pd.DataFrame) -> nx.Graph:
   """Converts an adjacency matrix to a network\n
   | Arguments:
   | :-
@@ -201,7 +201,7 @@ def adjacencyMatrix_to_network(adjacency_matrix):
   return network
 
 
-def create_adjacency_matrix(glycans, graph_dic, min_size = 1):
+def create_adjacency_matrix(glycans: list[str], graph_dic: dict[str, nx.Graph], min_size: int = 1) -> tuple[nx.Graph, list[str]]:
   """Creates a biosynthetic adjacency matrix from a list of glycans\n
   | Arguments:
   | :-
@@ -244,7 +244,7 @@ def create_adjacency_matrix(glycans, graph_dic, min_size = 1):
   return adjacencyMatrix_to_network(df_out.add(df_out.T, fill_value = 0)), new_nodes
 
 
-def shells_to_edges(prev_shell, next_shell):
+def shells_to_edges(prev_shell: list[list[str]], next_shell: list[list[str]]) -> list[list[tuple[str, str]]]:
   """Map virtual node generations to edges\n
   | Arguments:
   | :-
@@ -257,8 +257,8 @@ def shells_to_edges(prev_shell, next_shell):
   return [unwrap([[(prev_shell[m][k], next_shell[k][j]) for j in range(len(next_shell[k]))] for k in range(len(prev_shell[m]))]) for m in range(len(prev_shell))]
 
 
-def find_path(glycan_a, glycan_b, graph_dic,
-              permitted_roots = permitted_roots, min_size = 1, allowed_ptms = allowed_ptms):
+def find_path(glycan_a: str, glycan_b: str, graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
+              min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> tuple[list[tuple[str, str]], dict[tuple[str, str], str]]:
   """Find virtual node path between two glycans\n
   | Arguments:
   | :-
@@ -287,8 +287,8 @@ def find_path(glycan_a, glycan_b, graph_dic,
   return virtual_edges, {el: find_diff(el[0], el[1], graph_dic, allowed_ptms = allowed_ptms) for el in virtual_edges}
 
 
-def find_shortest_path(goal_glycan, glycan_list, graph_dic,
-                       permitted_roots = permitted_roots, min_size = 1, allowed_ptms = allowed_ptms):
+def find_shortest_path(goal_glycan: str, glycan_list: list[str], graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
+                       min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> tuple[list[tuple[str, str]], dict[tuple[str, str], str]]:
   """Finds the glycan with the shortest path via virtual nodes to the goal glycan\n
   | Arguments:
   | :-
@@ -316,7 +316,7 @@ def find_shortest_path(goal_glycan, glycan_list, graph_dic,
   return [], {}
 
 
-def filter_disregard(network, attr = 'diffs', value = 'disregard'):
+def filter_disregard(network: nx.Graph, attr: str = 'diffs', value: str = 'disregard') -> nx.Graph:
   """Filters out mistaken edges\n
   | Arguments:
   | :-
@@ -330,7 +330,7 @@ def filter_disregard(network, attr = 'diffs', value = 'disregard'):
   return network
 
 
-def stemify_glycan_fast(ggraph_in, stem_lib):
+def stemify_glycan_fast(ggraph_in: nx.Graph, stem_lib: dict[str, str]) -> tuple[str, nx.Graph]:
   """Stemifies a glycan graph\n
   | Arguments:
   | :-
@@ -345,8 +345,9 @@ def stemify_glycan_fast(ggraph_in, stem_lib):
   return graph_to_string(ggraph), ggraph
 
 
-def find_ptm(glycan, glycans, graph_dic, stem_lib, allowed_ptms = allowed_ptms,
-             ggraphs = None, suffix = '-ol'):
+def find_ptm(glycan: str, glycans: list[str], graph_dic: dict[str, nx.Graph], stem_lib: dict[str, str],
+             allowed_ptms: frozenset[str] = allowed_ptms, ggraphs: list[nx.Graph] | None = None, 
+             suffix: str = '-ol') -> tuple[tuple[str, str], str] | int:
   """Identifies precursor glycans for a glycan with a PTM\n
   | Arguments:
   | :-
@@ -386,7 +387,8 @@ def find_ptm(glycan, glycans, graph_dic, stem_lib, allowed_ptms = allowed_ptms,
     return 0
 
 
-def process_ptm(glycans, graph_dic, stem_lib, allowed_ptms = allowed_ptms, suffix = '-ol'):
+def process_ptm(glycans: list[str], graph_dic: dict[str, nx.Graph], stem_lib: dict[str, str],
+                allowed_ptms: frozenset[str] = allowed_ptms, suffix: str = '-ol') -> tuple[list, list]:
   """Identifies glycans that contain post-translational modifications and their biosynthetic precursor\n
   | Arguments:
   | :-
@@ -412,7 +414,8 @@ def process_ptm(glycans, graph_dic, stem_lib, allowed_ptms = allowed_ptms, suffi
     return [], []
 
 
-def update_network(network_in, edge_list, edge_labels = None, node_labels = None):
+def update_network(network_in: nx.Graph, edge_list: list[tuple[str, str]], edge_labels: list[str] | None = None,
+                  node_labels: dict[str, int] | None = None) -> nx.Graph:
   """Updates a network with new edges and their labels\n
   | Arguments:
   | :-
@@ -434,7 +437,7 @@ def update_network(network_in, edge_list, edge_labels = None, node_labels = None
   return network
 
 
-def return_unconnected_to_root(network, permitted_roots = permitted_roots):
+def return_unconnected_to_root(network: nx.Graph, permitted_roots: frozenset[str] = permitted_roots) -> set[str]:
   """Finds observed nodes that are not connected to the root nodes\n
   | Arguments:
   | :-
@@ -449,8 +452,8 @@ def return_unconnected_to_root(network, permitted_roots = permitted_roots):
   return set(filter(lambda node: not any(nx.has_path(network, node, root) for root in permitted_roots), candidate_nodes))
 
 
-def deorphanize_nodes(network, graph_dic, permitted_roots = permitted_roots, min_size = 1,
-                                        allowed_ptms = allowed_ptms):
+def deorphanize_nodes(network: nx.Graph, graph_dic: dict[str, nx.Graph], permitted_roots: frozenset[str] = permitted_roots,
+                     min_size: int = 1, allowed_ptms: frozenset[str] = allowed_ptms) -> nx.Graph:
   """Finds nodes unconnected to root nodes and tries to connect them\n
   | Arguments:
   | :-
@@ -493,7 +496,7 @@ def deorphanize_nodes(network, graph_dic, permitted_roots = permitted_roots, min
   return update_network(network, edges, edge_labels = edge_labels, node_labels = node_labels)
 
 
-def prune_directed_edges(network):
+def prune_directed_edges(network: nx.DiGraph) -> nx.DiGraph:
   """Removes edges that go against the direction of biosynthesis\n
   | Arguments:
   | :-
@@ -506,7 +509,7 @@ def prune_directed_edges(network):
   return network
 
 
-def deorphanize_edge_labels(network, graph_dic, allowed_ptms = allowed_ptms):
+def deorphanize_edge_labels(network: nx.Graph, graph_dic: dict[str, nx.Graph], allowed_ptms: frozenset[str] = allowed_ptms) -> nx.Graph:
   """Completes edge labels in newly added edges of a biosynthetic network\n
   | Arguments:
   | :-
@@ -524,7 +527,7 @@ def deorphanize_edge_labels(network, graph_dic, allowed_ptms = allowed_ptms):
 
 
 @lru_cache(maxsize = None)
-def infer_roots(glycans):
+def infer_roots(glycans: frozenset[str]) -> frozenset[str]:
   """Infers the correct permitted roots, given the glycan class\n
   | Arguments:
   | :-
@@ -551,7 +554,7 @@ def infer_roots(glycans):
     print("Glycan class not detected; depending on the class, glycans should end in -ol, GalNAc, GlcNAc, or 1Cer")
 
 
-def add_high_man_removal(network):
+def add_high_man_removal(network: nx.Graph) -> nx.Graph:
   """Considers the process of cutting down high-mannose N-glycans for maturation\n
   | Arguments:
   | :-
@@ -567,8 +570,8 @@ def add_high_man_removal(network):
 
 
 @rescue_glycans
-def construct_network(glycans, allowed_ptms = allowed_ptms,
-                      edge_type = 'monolink', permitted_roots = None, abundances = []):
+def construct_network(glycans: list[str], allowed_ptms: frozenset[str] = allowed_ptms, edge_type: str = 'monolink',
+                      permitted_roots: frozenset[str] | None = None, abundances: list[float] = []) -> nx.DiGraph:
   """Construct a glycan biosynthetic network\n
   | Arguments:
   | :-
@@ -670,8 +673,8 @@ def construct_network(glycans, allowed_ptms = allowed_ptms,
   return filter_disregard(network)
 
 
-def plot_network(network, plot_format = 'pydot2', edge_label_draw = True,
-                 lfc_dict = None):
+def plot_network(network: nx.Graph, plot_format: str = 'pydot2', 
+                edge_label_draw: bool = True, lfc_dict: dict[str, float] | None = None) -> None:
   """Visualizes biosynthetic network\n
   | Arguments:
   | :-
@@ -727,7 +730,7 @@ def plot_network(network, plot_format = 'pydot2', edge_label_draw = True,
   mpld3.plugins.connect(fig, tooltip)
 
 
-def network_alignment(network_a, network_b):
+def network_alignment(network_a: nx.Graph, network_b: nx.Graph) -> nx.Graph:
   """Combines two networks into a new network\n
   | Arguments:
   | :-
@@ -758,7 +761,8 @@ def network_alignment(network_a, network_b):
   return U
 
 
-def infer_virtual_nodes(network_a, network_b, combined = None):
+def infer_virtual_nodes(network_a: nx.Graph, network_b: nx.Graph,
+                       combined: nx.Graph | None = None) -> tuple[tuple[list[str], list[str]], tuple[list[str], list[str]]]:
   """Identifies virtual nodes that have been observed in other species\n
   | Arguments:
   | :-
@@ -785,7 +789,7 @@ def infer_virtual_nodes(network_a, network_b, combined = None):
   return (list(inferred_a), list(supported_a)), (list(inferred_b), list(supported_b))
 
 
-def infer_network(network, network_species, species_list, network_dic):
+def infer_network(network: nx.Graph, network_species: str, species_list: list[str], network_dic: dict[str, nx.Graph]) -> nx.Graph:
   """Replaces virtual nodes if they are observed in other species\n
   | Arguments:
   | :-
@@ -811,7 +815,7 @@ def infer_network(network, network_species, species_list, network_dic):
   return network2
 
 
-def retrieve_inferred_nodes(network, species = None):
+def retrieve_inferred_nodes(network: nx.Graph, species: str | None = None) -> list[str] | dict[str, list[str]]:
   """Returns the inferred virtual nodes of a network that has been used with infer_network\n
   | Arguments:
   | :-
@@ -824,7 +828,7 @@ def retrieve_inferred_nodes(network, species = None):
   return {species: inferred_nodes} if species is not None else inferred_nodes
 
 
-def export_network(network, filepath, other_node_attributes = None):
+def export_network(network: nx.Graph, filepath: str, other_node_attributes: list[str] | None = None) -> None:
   """Converts NetworkX network into files usable, e.g., by Cytoscape or Gephi\n
   | Arguments:
   | :-
@@ -850,8 +854,8 @@ def export_network(network, filepath, other_node_attributes = None):
   pd.DataFrame(node_labels_dict).to_csv(f"{filepath}_node_labels.csv", index = False)
 
 
-def monolink_to_glycoenzyme(edge_label, df, enzyme_column = 'glycoenzyme',
-                            monolink_column = 'monolink', mode = 'condensed'):
+def monolink_to_glycoenzyme(edge_label: str, df: pd.DataFrame, enzyme_column: str = 'glycoenzyme',
+                           monolink_column: str = 'monolink', mode: str = 'condensed') -> str:
   """Replaces monosaccharide(linkage) edge label by the name of the enzyme responsible for its synthesis\n
   | Arguments:
   | :-
@@ -869,7 +873,8 @@ def monolink_to_glycoenzyme(edge_label, df, enzyme_column = 'glycoenzyme',
   return '_'.join(new_edge_label) if new_edge_label.size else edge_label
 
 
-def choose_path(diamond, species_list, network_dic, threshold = 0., nb_intermediates = 2, mode = 'presence'):
+def choose_path(diamond: dict[int, str], species_list: list[str], network_dic: dict[str, nx.Graph], threshold: float = 0.,
+                nb_intermediates: int = 2, mode: str = 'presence') -> dict[str, float]:
   """Given a shape such as diamonds in biosynthetic networks (A->B,A->C,B->D,C->D), which path is taken from A to D?\n
   | Arguments:
   | :-
@@ -910,7 +915,7 @@ def choose_path(diamond, species_list, network_dic, threshold = 0., nb_intermedi
   return {k[0]: v for k, v in alts.items()} if nb_intermediates == 2 else alts
 
 
-def find_diamonds(network, nb_intermediates = 2, mode = 'presence'):
+def find_diamonds(network: nx.Graph, nb_intermediates: int = 2, mode: str = 'presence') -> list[dict[int, str]]:
   """Automatically extracts shapes such as diamonds (A->B,A->C,B->D,C->D) from biosynthetic networks\n
   | Arguments:
   | :-
@@ -959,7 +964,8 @@ def find_diamonds(network, nb_intermediates = 2, mode = 'presence'):
   return final_matchings
 
 
-def trace_diamonds(network, species_list, network_dic, threshold = 0., nb_intermediates = 2, mode = 'presence'):
+def trace_diamonds(network: nx.Graph, species_list: list[str], network_dic: dict[str, nx.Graph], threshold: float = 0.,
+                  nb_intermediates: int = 2, mode: str = 'presence') -> pd.DataFrame:
   """Extracts diamond-shape motifs from biosynthetic networks (A->B,A->C,B->D,C->D) and uses evolutionary information to determine which path is taken from A to D\n
   | Arguments:
   | :-
@@ -982,7 +988,7 @@ def trace_diamonds(network, species_list, network_dic, threshold = 0., nb_interm
   return df_out
 
 
-def prune_network(network, node_attr = 'abundance', threshold = 0.):
+def prune_network(network: nx.Graph, node_attr: str = 'abundance', threshold: float = 0.) -> nx.Graph:
   """Pruning a network by dismissing unlikely virtual paths\n
   | Arguments:
   | :-
@@ -1007,8 +1013,8 @@ def prune_network(network, node_attr = 'abundance', threshold = 0.):
   return network_out
 
 
-def evoprune_network(network, network_dic = None, species_list = None, node_attr = 'abundance',
-                     threshold = 0.01, nb_intermediates = 2, mode = 'presence'):
+def evoprune_network(network: nx.Graph, network_dic: dict[str, nx.Graph] | None = None, species_list: list[str] | None = None,
+                     node_attr: str = 'abundance', threshold: float = 0.01, nb_intermediates: int = 2, mode: str = 'presence') -> nx.Graph:
   """Given a biosynthetic network, this function uses evolutionary relationships to prune impossible paths\n
   | Arguments:
   | :-
@@ -1036,10 +1042,9 @@ def evoprune_network(network, network_dic = None, species_list = None, node_attr
   return prune_network(network_out, node_attr = node_attr, threshold = threshold*100)
 
 
-def highlight_network(network, highlight, motif = None,
-                      abundance_df = None, glycan_col = 'glycan',
-                      intensity_col = 'rel_intensity', conservation_df = None,
-                      network_dic = None, species = None):
+def highlight_network(network: nx.Graph, highlight: str, motif: str | None = None, abundance_df: pd.DataFrame | None = None,
+                      glycan_col: str = 'glycan', intensity_col: str = 'rel_intensity', conservation_df: pd.DataFrame | None = None,
+                      network_dic: dict[str, nx.Graph] | None = None, species: str | None = None) -> nx.Graph:
   """Highlights a certain attribute in the network that will be visible when using plot_network\n
   | Arguments:
   | :-
@@ -1103,7 +1108,7 @@ def highlight_network(network, highlight, motif = None,
   return network_out
 
 
-def get_edge_weight_by_abundance(network, root = "Gal(b1-4)Glc-ol", root_default = 10.0):
+def get_edge_weight_by_abundance(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol", root_default: float = 10.0) -> nx.Graph:
   """Estimate reaction capacity by the relative abundance of source and sink\n
   | Arguments:
   | :-
@@ -1123,7 +1128,7 @@ def get_edge_weight_by_abundance(network, root = "Gal(b1-4)Glc-ol", root_default
   return network
 
 
-def estimate_weights(network, root = "Gal(b1-4)Glc-ol", root_default = 10, min_default = 0.001):
+def estimate_weights(network: nx.Graph, root: str = "Gal(b1-4)Glc-ol", root_default: float = 10, min_default: float = 0.001) -> nx.Graph:
   """Estimate reaction capacity of edges and missing relative abundances\n
   | Arguments:
   | :-
@@ -1149,7 +1154,8 @@ def estimate_weights(network, root = "Gal(b1-4)Glc-ol", root_default = 10, min_d
   return net_estimated
 
 
-def get_maximum_flow(network, source = "Gal(b1-4)Glc-ol", sinks = None):
+def get_maximum_flow(network: nx.Graph, source: str = "Gal(b1-4)Glc-ol", 
+                    sinks: list[str] | None = None) -> dict[str, dict[str, float | dict[str, dict[str, float]]]]:
   """Estimate maximum flow and flow paths between source and sinks\n
   | Arguments:
   | :-
@@ -1179,7 +1185,8 @@ def get_maximum_flow(network, source = "Gal(b1-4)Glc-ol", sinks = None):
   return flow_results
 
 
-def get_max_flow_path(network, flow_dict, sink, source = "Gal(b1-4)Glc-ol"):
+def get_max_flow_path(network: nx.Graph, flow_dict: dict[str, dict[str, float]], 
+                     sink: str, source: str = "Gal(b1-4)Glc-ol") -> list[tuple[str, str]]:
   """Get the actual path between source and sink that gave rise to the maximum flow value\n
   | Arguments:
   | :-
@@ -1205,7 +1212,8 @@ def get_max_flow_path(network, flow_dict, sink, source = "Gal(b1-4)Glc-ol"):
   return path
 
 
-def get_reaction_flow(network, res, aggregate = None):
+def get_reaction_flow(network: nx.Graph, res: dict[str, dict[str, float]], 
+                     aggregate: str | None = None) -> dict[str, list[float]] | dict[str, float]:
   """Get the aggregated flows for a type of reaction across entire network\n
   | Arguments:
   | :-
@@ -1229,7 +1237,9 @@ def get_reaction_flow(network, res, aggregate = None):
   return reaction_flows
 
 
-def get_differential_biosynthesis(df, group1, group2 = None, analysis = "reaction", paired = False, longitudinal = False, id_column = "ID"):
+def get_differential_biosynthesis(df: pd.DataFrame | str, group1: list[str | int], group2: list[str | int] | None = None, 
+                                analysis: str = "reaction", paired: bool = False, longitudinal: bool = False, 
+                                id_column: str = "ID") -> pd.DataFrame:
   """Compares biosynthetic patterns between glycomes of two conditions or across multiple time points\n
   | Arguments:
   | :-
@@ -1375,7 +1385,7 @@ def get_differential_biosynthesis(df, group1, group2 = None, analysis = "reactio
   return out.dropna().sort_values(by = 'p-val')
 
 
-def extend_glycans(glycans, reactions, allowed_disaccharides = None):
+def extend_glycans(glycans: list[str] | set[str], reactions: list[str] | set[str], allowed_disaccharides: set[str] | None = None) -> set[str]:
   """Given a set of reactions, tries to extend observed glycans\n
   | Arguments:
   | :-
@@ -1393,7 +1403,8 @@ def extend_glycans(glycans, reactions, allowed_disaccharides = None):
   return new_glycans
 
 
-def edges_for_extension(leaf_glycans, new_glycans, graphs):
+def edges_for_extension(leaf_glycans: set[str], new_glycans: set[str],
+                       graphs: dict[str, nx.Graph]) -> tuple[list[tuple[str, str]], list[str]]:
   """Given leaf nodes and their extensions, creates the corresponding edges and edge labels\n
   | Arguments:
   | :-
@@ -1418,7 +1429,7 @@ def edges_for_extension(leaf_glycans, new_glycans, graphs):
   return new_edges, new_edge_labels
 
 
-def choose_leaves_to_extend(leaf_glycans, target_composition):
+def choose_leaves_to_extend(leaf_glycans: set[str], target_composition: dict[str, int]) -> set[str]:
   """Given a target composition to be reached, pick the best one or more leaf nodes to extend\n
   | Arguments:
   | :-
@@ -1442,7 +1453,8 @@ def choose_leaves_to_extend(leaf_glycans, target_composition):
   return {glycan for glycan, score in scored_glycans if score == min_score}
 
 
-def extend_network(network, steps = 1, to_extend = "all", strict_context = False):
+def extend_network(network: nx.Graph, steps: int = 1, to_extend: str | dict[str, int] | list[str] = "all",
+                  strict_context: bool = False) -> tuple[nx.Graph, set[str]]:
   """Given a biosynthetic network, tries to extend it in a physiological manner\n
   | Arguments:
   | :-

--- a/glycowork/network/evolution.py
+++ b/glycowork/network/evolution.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import networkx as nx
 import matplotlib.pyplot as plt
-from typing import Callable
+from typing import Dict, List, Union, Optional, Callable
 from scipy.spatial.distance import cosine
 from scipy.cluster.hierarchy import dendrogram, linkage
 from glycowork.motif.graph import subgraph_isomorphism
@@ -14,17 +14,11 @@ data_path = os.path.join(this_dir, 'milk_networks_exhaustive.pkl')
 net_dic = pickle.load(open(data_path, 'rb'))
 
 
-def calculate_distance_matrix(to_compare: dict[str, list] | list, dist_func: Callable[[list, list], float], 
-                            label_list: list[str] | None = None) -> pd.DataFrame:
-  """calculates pairwise distances based on objects and a metric\n
-  | Arguments:
-  | :-
-  | to_compare (dict or list): objects to calculate pairwise distances for, if dict then values have to be lists
-  | dist_func (function): function such as 'jaccard' or 'cosine' that calculates distance given two lists/elements
-  | label_list (list): column names for the resulting distance matrix; default:range(len(to_compare))\n
-  | Returns:
-  | :-
-  | Returns a len(to_compare) x len(to_compare) distance matrix"""
+def calculate_distance_matrix(to_compare: Union[Dict[str, List], List], # Objects to compare - dict values must be lists
+                            dist_func: Callable[[List, List], float], # Distance function such as jaccard or cosine
+                            label_list: Optional[List[str]] = None # Column names for distance matrix
+                           ) -> pd.DataFrame: # Square distance matrix
+  "Calculate pairwise distances between objects using provided metric"
   n = len(to_compare)
   dm = np.zeros((n, n))
   # Check whether comparison objects are in a dict or list
@@ -46,19 +40,13 @@ def calculate_distance_matrix(to_compare: dict[str, list] | list, dist_func: Cal
   return dm
 
 
-def distance_from_embeddings(df: pd.DataFrame, embeddings: pd.DataFrame, 
-                           cut_off: int = 10, rank: str = 'Species', averaging: str = 'median') -> pd.DataFrame:
-  """calculates a cosine distance matrix from learned embeddings\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycans as rows and taxonomic information as columns
-  | embeddings (dataframe): dataframe with glycans as rows and learned embeddings as columns (e.g., from glycans_to_emb)
-  | cut_off (int): how many glycans a rank (e.g., species) needs to have at least to be included; default:10
-  | rank (string): which taxonomic rank to use for grouping organisms; default:'Species'
-  | averaging (string): how to average embeddings, by 'median' or 'mean'; default:'median'\n
-  | Returns:
-  | :-
-  | Returns a rank x rank distance matrix"""
+def distance_from_embeddings(df: pd.DataFrame, # DataFrame with glycans (rows) and taxonomic info (columns)
+                           embeddings: pd.DataFrame, # DataFrame with glycans (rows) and embeddings (columns) (e.g., from glycans_to_emb)
+                           cut_off: int = 10, # Minimum glycans per rank to be included; default:10
+                           rank: str = 'Species', # Taxonomic rank for grouping; default:Species
+                           averaging: str = 'median' # How to average embeddings: median/mean
+                          ) -> pd.DataFrame: # Rank x rank distance matrix
+  "Calculate cosine distance matrix from learned embeddings"
   if averaging not in ['mean', 'median']:
     print("Only 'median' and 'mean' are permitted averaging choices.")
     return
@@ -75,33 +63,22 @@ def distance_from_embeddings(df: pd.DataFrame, embeddings: pd.DataFrame,
   return calculate_distance_matrix(avg_values, cosine, label_list = valid_ranks)
 
 
-def jaccard(list1: list | nx.Graph, list2: list | nx.Graph) -> float:
-  """calculates Jaccard distance from two networks\n
-  | Arguments:
-  | :-
-  | list1 (list or networkx graph): list containing objects to compare
-  | list2 (list or networkx graph): list containing objects to compare\n
-  | Returns:
-  | :-
-  | Returns Jaccard distance between list1 and list2"""
+def jaccard(list1: Union[List, nx.Graph], # First list/network to compare
+            list2: Union[List, nx.Graph] # Second list/network to compare
+           ) -> float: # Jaccard distance
+  "Calculate Jaccard distance between two lists/networks"
   intersection = len(set(list1).intersection(list2))
   union = (len(list1) + len(list2)) - intersection
   return 1 - float(intersection) / union
 
 
-def distance_from_metric(df: pd.DataFrame, networks: list[nx.Graph], 
-                        metric: str = "Jaccard", cut_off: int = 10, rank: str = "Species") -> pd.DataFrame:
-  """calculates a distance matrix of generated networks based on provided metric\n
-  | Arguments:
-  | :-
-  | df (dataframe): dataframe with glycans as rows and taxonomic information as columns
-  | networks (list): list of networks in networkx format
-  | metric (string): which metric to use, available: 'Jaccard'; default:'Jaccard'
-  | cut_off (int): how many glycans a rank (e.g., species) needs to have at least to be included; default:10
-  | rank (string): which taxonomic rank to use for grouping organisms; default:'Species'\n
-  | Returns:
-  | :-
-  | Returns a rank x rank distance matrix"""
+def distance_from_metric(df: pd.DataFrame, # DataFrame with glycans (rows) and taxonomic info (columns)
+                        networks: List[nx.Graph], # List of networkx networks
+                        metric: str = "Jaccard", # Distance metric to use
+                        cut_off: int = 10, # Minimum glycans per rank to be included; default:10
+                        rank: str = "Species" # Taxonomic rank for grouping; default:Species
+                       ) -> pd.DataFrame: # Rank x rank distance matrix
+  "Calculate distance matrix between networks using provided metric"
   # Choose distance metric
   metric_funcs = {"Jaccard": jaccard}
   dist_func = metric_funcs.get(metric)
@@ -116,13 +93,11 @@ def distance_from_metric(df: pd.DataFrame, networks: list[nx.Graph],
   return calculate_distance_matrix(valid_networks, dist_func, label_list = valid_ranks.tolist())
 
 
-def dendrogram_from_distance(dm: pd.DataFrame, ylabel: str = 'Mammalia', filepath: str = '') -> None:
-  """plots a dendrogram from distance matrix\n
-  | Arguments:
-  | :-
-  | dm (dataframe): a rank x rank distance matrix (e.g., from distance_from_embeddings)
-  | ylabel (string): how to label the y-axis of the dendrogram; default:'Mammalia'
-  | filepath (string): absolute path including full filename allows for saving the plot\n"""
+def dendrogram_from_distance(dm: pd.DataFrame, # Rank x rank distance matrix (e.g., from distance_from_embeddings)
+                           ylabel: str = 'Mammalia', # Y-axis label
+                           filepath: str = '' # Path to save plot including filename
+                          ) -> None: # Displays or saves dendrogram plot
+  "Plot dendrogram from distance matrix"
   # Hierarchical clustering on the distance matrix
   Z = linkage(dm)
   plt.figure(figsize = (10, 10))
@@ -145,20 +120,14 @@ def dendrogram_from_distance(dm: pd.DataFrame, ylabel: str = 'Mammalia', filepat
                 bbox_inches = 'tight')
 
 
-def check_conservation(glycan: str, df: pd.DataFrame, network_dic: dict[str, nx.Graph] | None = None, 
-                      rank: str = 'Order', threshold: int = 5, motif: bool = False) -> dict[str, float]:
-  """estimates evolutionary conservation of glycans and glycan motifs via biosynthetic networks\n
-  | Arguments:
-  | :-
-  | glycan (string): full glycan or glycan motif in IUPAC-condensed nomenclature
-  | df (dataframe): dataframe in the style of df_species, each row one glycan and columns are the taxonomic levels
-  | network_dic (dict): dictionary of form species name : biosynthetic network (gained from construct_network); default:pre-computed milk networks
-  | rank (string): at which taxonomic level to assess conservation; default:Order
-  | threshold (int): threshold of how many glycans a species needs to have to consider the species;default:5
-  | motif (bool): whether glycan is a motif (True) or a full sequence (False); default:False\n
-  | Returns:
-  | :-
-  | Returns a dictionary of taxonomic group : degree of conservation"""
+def check_conservation(glycan: str, # Glycan or motif in IUPAC-condensed format
+                      df: pd.DataFrame, # DataFrame with glycans (rows) and taxonomic levels (columns)
+                      network_dic: Optional[Dict[str, nx.Graph]] = None, # Species:biosynthetic network mapping
+                      rank: str = 'Order', # Taxonomic level to assess
+                      threshold: int = 5, # Minimum glycans per species to be included
+                      motif: bool = False # Whether glycan is a motif vs sequence
+                     ) -> Dict[str, float]: # Taxonomic group-to-conservation mapping
+  "Estimate evolutionary conservation of glycans via biosynthetic networks"
   if network_dic is None:
     network_dic = net_dic
   # Subset species with at least the threshold-number of glycans
@@ -187,15 +156,10 @@ def check_conservation(glycan: str, df: pd.DataFrame, network_dic: dict[str, nx.
   return conserved
 
 
-def get_communities(network_list: list[nx.Graph], label_list: list[str] | None = None) -> dict[str, list[str]]:
-  """Find communities for each graph in a list of graphs\n
-  | Arguments:
-  | :-
-  | network_list (list): list of undirected biosynthetic networks, in the form of networkx objects
-  | label_list (list): labels to create the community names, which are running_number + _ + label[k]  for graph_list[k]; default:range(len(graph_list))\n
-  | Returns:
-  | :-
-  | Returns a merged dictionary of community : glycans in that community"""
+def get_communities(network_list: List[nx.Graph], # List of undirected biosynthetic networks
+                   label_list: Optional[List[str]] = None # Labels for community names, running_number + _ + label_list[k]  for network_list[k]; default:range(len(graph_list))
+                  ) -> Dict[str, List[str]]: # Community-to-glycan list mapping
+  "Find communities for each graph in list of graphs"
   if label_list is None:
     label_list = list(range(len(network_list)))
   final_comm_dict = {}


### PR DESCRIPTION
I reworked the metric-handling in the `train_model` function by changing the following:

- Adding metrics. The metric calculations are still fully based on the `scikit-learn`. It now tracks the following:
    - ACC, MCC, and AUROC (new) for single- and multi-class classification
    - ACC (new), MCC (new), LRAP, and NDCG for multilabel classification
    - MSE, MAE (new), and R2 (new) for regression
- Weighting of the metrics when summarizing based on individual batch sizes (the last batch might be smaller than the others). It only has minor effects, but it is still more precise.
- The best performances are now taken from the best model (not the best ever-seen value which might come from a different model).
- The best model is determined based on the lowest loss value (applies to all classification and regression settings).
- The function has a new boolean parameter `return_metrics`, which defaults to `False` to preserve the old behaviour. If set to `True`, the function returns the best model and all training and validation metrics as a tuple of type `Tuple[torch.nn.Module, dict["train": dict[...], "val": dict[...]]]`.
- Added comment to the `optimizer` argument that it has to be a SAM optimizer for classification settings. The standard optimizers like Adam don't have `first_step` and `second_step` functionality.
- Telling names. Before, `best_acc` could have been an actual accuracy, an MSE, or some LRAP. This functionality has been replaced by a variable called `best_lead_metric` that is inferred from the validation ACC, MSE, or LRAP.

The new code is tested for a LectinOracle training (works) and should not tamper with the old behaviour, i. e., everything possible before, is still possible. Only the selection of the best model has changed to be `loss`-based and not lead-metric-based (`best_acc` before).