### PR TITLE
Rework of train_model function

### DIFF
--- a/glycowork/ml/model_training.py
+++ b/glycowork/ml/model_training.py
@@ -85,27 +85,19 @@ def enable_running_stats(model: torch.nn.Module # model to enable batch norm
     model.apply(_enable)
 
 
-def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.DataLoader], criterion: torch.nn.Module,
-                optimizer: torch.optim.Optimizer, scheduler: torch.optim.lr_scheduler._LRScheduler,
-                num_epochs: int = 25, patience: int = 50, mode: str = 'classification', mode2: str = 'multi',
-                return_metrics: bool = False
-                ) -> Union[torch.nn.Module, tuple[torch.nn.Module, dict[str, dict[str, list[float]]]]]:
-    """trains a deep learning model on predicting glycan properties\n
-    | Arguments:
-    | :-
-    | model (PyTorch object): graph neural network (such as SweetNet) for analyzing glycans
-    | dataloaders (PyTorch object): dictionary of dataloader objects with keys 'train' and 'val'
-    | criterion (PyTorch object): PyTorch loss function
-    | optimizer (PyTorch object): PyTorch optimizer
-    | scheduler (PyTorch object): PyTorch learning rate decay
-    | num_epochs (int): number of epochs for training; default:25
-    | patience (int): number of epochs without improvement until early stop; default:50
-    | mode (string): 'classification', 'multilabel', or 'regression'; default:classification
-    | mode2 (string): further specifying classification into 'multi' or 'binary' classification;default:multi\n
-    | return_metrics (bool): whether to return metrics, if false, plots will be generated; default:False\n
-    | Returns:
-    | :-
-    | Returns the best model seen during training"""
+def train_model(model: torch.nn.Module, # graph neural network for analyzing glycans
+               dataloaders: Dict[str, torch.utils.data.DataLoader], # dict with 'train' and 'val' loaders
+               criterion: torch.nn.Module, # PyTorch loss function
+               optimizer: torch.optim.Optimizer, # PyTorch optimizer, has to be SAM if mode != "regression"
+               scheduler: torch.optim.lr_scheduler._LRScheduler, # PyTorch learning rate decay
+               num_epochs: int = 25, # number of epochs for training
+               patience: int = 50, # epochs without improvement until early stop
+               mode: str = 'classification', # 'classification', 'multilabel', or 'regression'
+               mode2: str = 'multi', # 'multi' or 'binary' classification
+               return_metrics: bool = False, # whether to return metrics
+              ) -> Union[torch.nn.Module, tuple[torch.nn.Module, dict[str, dict[str, list[float]]]]]: # best model from training and the training and validation metrics
+    "trains a deep learning model on predicting glycan properties"
+
     since = time.time()
     early_stopping = EarlyStopping(patience=patience, verbose=True)
     best_model_wts = copy.deepcopy(model.state_dict())
@@ -119,7 +111,7 @@ def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.
     else:
         blank_metrics = {"loss": [], "mse": [], "mae": [], "r2": []}
 
-    metrics = {"train": copy.copy(blank_metrics), "val": copy.copy(blank_metrics)}
+    metrics = {"train": copy.deepcopy(blank_metrics), "val": copy.deepcopy(blank_metrics)}
 
     for epoch in range(num_epochs):
         print('Epoch {}/{}'.format(epoch, num_epochs - 1))
@@ -131,7 +123,7 @@ def train_model(model: torch.nn.Module, dataloaders: dict[str, torch.utils.data.
             else:
                 model.eval()
 
-            running_metrics = copy.copy(blank_metrics)
+            running_metrics = copy.deepcopy(blank_metrics)
             running_metrics["weights"] = []
 
             for data in dataloaders[phase]:

--- a/glycowork/ml/model_training.py
+++ b/glycowork/ml/model_training.py
@@ -169,7 +169,7 @@ def train_model(model: torch.nn.Module, # graph neural network for analyzing gly
 
                 # Collecting relevant metrics
                 running_metrics["loss"].append(loss.item())
-                running_metrics["weights"].append(len(batch))
+                running_metrics["weights"].append(batch.max().cpu() + 1)
 
                 y_det = y.detach().cpu().numpy()
                 pred_det = pred.cpu().detach().numpy()
@@ -210,7 +210,7 @@ def train_model(model: torch.nn.Module, # graph neural network for analyzing gly
                     best_loss = metrics[phase]["loss"][-1]
                     best_model_wts = copy.deepcopy(model.state_dict())
 
-                    # Extract ACC or MSE of the new best model
+                    # Extract the lead metric (ACC, LRAP, or MSE) of the new best model
                     if mode == 'classification':
                         best_lead_metric = metrics[phase]["acc"][-1]
                     elif mode == 'multilabel':

--- a/glycowork/ml/models.py
+++ b/glycowork/ml/models.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal
+from typing import Literal, Optional
 
 import numpy as np
 try:
@@ -310,7 +310,7 @@ def init_weights(model: torch.nn.Module, mode: str = 'sparse', sparsity: float =
 
 
 def prep_model(model_type: Literal["SweetNet", "LectinOracle", "LectinOracle_flex", "NSequonPred"],
-               num_classes: int, libr: dict[str, int] | None = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
+               num_classes: int, libr: Optional[dict[str, int]] = None, trained: bool = False, hidden_dim: int = 128) -> torch.nn.Module:
     """wrapper to instantiate model, initialize it, and put it on the GPU\n
     | Arguments:
     | :-


### PR DESCRIPTION
I reworked the metric-handling in the `train_model` function by changing the following:

- Adding metrics. The metric calculations are still fully based on the `scikit-learn`. It now tracks the following:
    - ACC, MCC, and AUROC (new) for single- and multi-class classification
    - ACC (new), MCC (new), LRAP, and NDCG for multilabel classification
    - MSE, MAE (new), and R2 (new) for regression
- Weighting of the metrics when summarizing based on individual batch sizes (the last batch might be smaller than the others). It only has minor effects, but it is still more precise.
- The best performances are now taken from the best model (not the best ever-seen value which might come from a different model).
- The best model is determined based on the lowest loss value (applies to all classification and regression settings).
- The function has a new boolean parameter `return_metrics`, which defaults to `False` to preserve the old behaviour. If set to `True`, the function returns the best model and all training and validation metrics as a tuple of type `Tuple[torch.nn.Module, dict["train": dict[...], "val": dict[...]]]`.
- Added comment to the `optimizer` argument that it has to be a SAM optimizer for classification settings. The standard optimizers like Adam don't have `first_step` and `second_step` functionality.
- Telling names. Before, `best_acc` could have been an actual accuracy, an MSE, or some LRAP. This functionality has been replaced by a variable called `best_lead_metric` that is inferred from the validation ACC, MSE, or LRAP.

The new code is tested for a LectinOracle training (works) and should not tamper with the old behaviour, i. e., everything possible before, is still possible. Only the selection of the best model has changed to be `loss`-based and not lead-metric-based (`best_acc` before).