### PR TITLE
fix(tests): update to `glyles~=1.2.3a0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ all = [
     "torch_geometric",
     "torch",
     "xgboost",
-    "glyles",
+    "glyles~=1.2.3a0",
     "pubchempy",
     "requests",
     "py3Dmol"
@@ -52,7 +52,7 @@ dev = [
     "torch_geometric",
     "torch",
     "xgboost",
-    "glyles",
+    "glyles~=1.2.3a0",
     "pubchempy",
     "requests",
     "py3Dmol",
@@ -64,7 +64,7 @@ ml = [
     "xgboost"
 ]
 chem = [
-    "glyles",
+    "glyles~=1.2.3a0",
     "pubchempy",
     "requests",
     "py3Dmol"


### PR DESCRIPTION
Updating to 1.2.3a0 or later means pulling in a newer `pydot` — which was needed to fix a dependency mismatch that was causing a test failure.

I'm updating all versions of `glyles`, not just the one under `[dev]`, so that the tests and main application don't use different versions of the same dependency. Otherwise test results could diverge from real usage!

Fixes #96 