### PR TITLE
docs(CONTRIBUTING): add note about Quarto install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ pip install -e ".[all,dev]"
 nbdev_install_hooks
 ```
 
+To run `nbdev_prepare` later on, you'll need Quarto installed. If you don't have it installed already, you can [install Quarto from here](https://quarto.org/docs/get-started/).
+
 ## Did you find a bug?
 
 * Ensure the bug was not already reported by searching on GitHub under Issues.


### PR DESCRIPTION
Whilst I'm at it, this was the last hurdle I encountered. Now I can pull `glycowork` into an empty container, install `git` and `uv`, then follow the instructions in `CONTRIBUTING.md` to get a fully functional install with all passing tests!