### PR TITLE
Update __version__ to 1.8.2 in __init__.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bumped minimum `pandas` version to `2.1` (faf68f0)
 - Fixed `scipy` version as `>=1.16` to guarantee Games-Howell test in the ANOVA for biodiversity tests (cf5e7bd)
 - The `dev` optional install set (only used for testing) now also includes `glycontact>=0.3.3`
+- Automate versioning in __init__.py
 
 ### glycan_data
 - Added new curated glycomics dataset: `human_interstitialfluid_N_GPST000651` (ce499ae, 7ddd6c2)

--- a/glycowork/__init__.py
+++ b/glycowork/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 from .motif.draw import GlycoDraw
 
 __all__ = ['GlycoDraw']

--- a/glycowork/__init__.py
+++ b/glycowork/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "1.8.2"
+from importlib.metadata import version
+__version__ = version("glycowork")
 from .motif.draw import GlycoDraw
 
 __all__ = ['GlycoDraw']


### PR DESCRIPTION
I noticed that pyproject.toml is updated to 1.8.2 in the dev branch, while __init__.py still points to 1.8.1.

# ⚠️ IMPORTANT: Branch Strategy

This repository follows a strict branch strategy:

- `master` branch is ONLY for PyPI release mirroring
- All development PRs MUST target the `dev` branch
- If your PR targets `master`, it will be flagged and you'll be asked to retarget to `dev`

---

## Description of Changes

...

## Changelog

- [ ] I have added my changes to CHANGELOG.md under the appropriate module/submodule section