### PR TITLE
Update max_specify_glycan coverage()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@
 ##### Changed 🔄
 - Universal Input via `canonicalize_iupac` now is more robust to modified reducing ends in IUPAC-extended glycans (6754bbf)
 - The `glycan_class` parameter is optional in `max_specify_glycan` and inferred using `get_class` (585b94a)
-- Added user-defined parameters (0486986)
-
+- Added user-defined parameters to `max_specify_glycan` (0486986)
+- Removed `tax` from `max_specify_glycan` (0d2976f)
+  
 ##### Fixed 🐛
 - Fixed some Oxford sequences (e.g., `A1`, `A2`) being misidentified as blood group glycolipids by `canonicalize_iupac` (9f42561)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,11 @@
 - Universal Input via `canonicalize_iupac` can now parse more complex Oxford sequences, such as `F(6)A2G(4)2S(3,3)2` (9f42561)
 - `max_specify_glycan` will now also specify these cases: `("Fuc(a1-?)GlcNAc", "Fuc(a1-3/4)GlcNAc")`, `("Fuc(a1-?)]GlcNAc", "Fuc(a1-3/4)]GlcNAc")`, `("Fuc(a1-?)Gal(", "Fuc(a1-2)Gal(")`, `("GalOS", "Gal3/6S"), ("GlcNAcOS", "GlcNAc6S")` (f3b4389)
 - Oxford parsing in `canonicalize_iupac` will now detect hybrid glycans and will add extra mannoses to the `a1-6` branch
-
+- `max_specify_glycan` accepts `glycan_class`, `taxonomy_level`, `taxonomy_filter`, and `df_use` (a sugarbase-like database of glycans) to improve the annotation of the sequences (2ddbcf3)
+  
 ##### Changed 🔄
 - Universal Input via `canonicalize_iupac` now is more robust to modified reducing ends in IUPAC-extended glycans (6754bbf)
+- Make `glycan_class` optional in `max_specify_glycan` and infer it automatically using `get_class` (585b94a)
 
 ##### Fixed 🐛
 - Fixed some Oxford sequences (e.g., `A1`, `A2`) being misidentified as blood group glycolipids by `canonicalize_iupac` (9f42561)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Universal Input via `canonicalize_iupac` now is more robust to modified reducing ends in IUPAC-extended glycans (6754bbf)
 - The `glycan_class` parameter is optional in `max_specify_glycan` and inferred using `get_class` (585b94a)
 - Added user-defined parameters to `max_specify_glycan` (0486986)
-- Removed `tax` from `max_specify_glycan` (0d2976f)
+- Fixed `df_glycan` filtering for `glycan_class` inferred by `get_class` (d9175a2)
   
 ##### Fixed 🐛
 - Fixed some Oxford sequences (e.g., `A1`, `A2`) being misidentified as blood group glycolipids by `canonicalize_iupac` (9f42561)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
   
 ##### Changed 🔄
 - Universal Input via `canonicalize_iupac` now is more robust to modified reducing ends in IUPAC-extended glycans (6754bbf)
-- Make `glycan_class` optional in `max_specify_glycan` and infer it automatically using `get_class` (585b94a)
+- The `glycan_class` parameter is optional in `max_specify_glycan` and inferred using `get_class` (585b94a)
+- Added user-defined parameters (0486986)
 
 ##### Fixed 🐛
 - Fixed some Oxford sequences (e.g., `A1`, `A2`) being misidentified as blood group glycolipids by `canonicalize_iupac` (9f42561)

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -1461,14 +1461,18 @@ def max_specify_glycan(glycan: str, # Glycan in IUPAC-condensed nomenclature
   if glycan_class is None:
     glycan_class = get_class(glycan)
   if df_use is None:
-    df_use = copy.deepcopy(df_glycan[df_glycan.glycan_type == glycan_class])
+    if glycan_class == "lipid/free":
+      df_use = df_glycan[df_glycan.glycan_type.isin(["lipid", "free"])]
+    else:
+      df_use = df_glycan[df_glycan.glycan_type == glycan_class]
+  tax = df_use[df_use[taxonomy_level].apply(lambda x: isinstance(x, list) and taxonomy_filter in x)]
   if glycan.endswith("GlcNAc(b1-?)GlcNAc"):
     glycan = glycan.replace("GlcNAc(b1-?)GlcNAc", "GlcNAc(b1-4)GlcNAc")
-  if taxonomy_level == "Kingdom" and taxonomy_filter == 'Animalia':
+  if (tax['Kingdom'].apply(lambda x: isinstance(x, list) and 'Animalia' in x)).any():
     glycan = glycan.replace("dHex", "Fuc")
     glycan = glycan.replace("Gal(b1-?)GlcNAc", "Gal(b1-3/4)GlcNAc")
   if "GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc" in glycan:
-    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if taxonomy_level == "Class" and taxonomy_filter == 'Mammalia' else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
+    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if (tax['Class'].apply(lambda x: isinstance(x, list) and 'Mammalia' in x)).any() else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
   for old, new in [("Neu5Ac(a2-?)Neu5Ac", "Neu5Ac(a2-8)Neu5Ac"), ("Neu5Ac(a2-?)", "Neu5Ac(a2-3/6)"), ("Neu5Gc(a2-?)Neu5Gc", "Neu5Gc(a2-8)Neu5Gc"), ("Neu5Gc(a2-?)", "Neu5Gc(a2-3/6)"),
                    ("Fuc(a1-?)GlcNAc", "Fuc(a1-3/4)GlcNAc"), ("Fuc(a1-?)]GlcNAc", "Fuc(a1-3/4)]GlcNAc"), ("Fuc(a1-?)Gal(", "Fuc(a1-2)Gal("), ("GalOS", "Gal3/6S"), ("GlcNAcOS", "GlcNAc6S")]:
     glycan = glycan.replace(old, new)

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -1450,17 +1450,22 @@ def is_composition(s: str # Either glycan or composition string
 
 
 def max_specify_glycan(glycan: str, # Glycan in IUPAC-condensed nomenclature
-                       species: str = "Homo_sapiens" # Species for biosynthetic inferences
+                       glycan_class: str, # "O", "N", "lipid", "free"
+                       taxonomy_level: str = "Kingdom", # Which taxonomy level to filter by
+                       taxonomy_filter: str = "Animalia", # Which taxonomy to pull glycans for
+                       df_use: pd.DataFrame = None # Which sugarbase-like database of glycans with species associations etc.
                       ) -> str: # Maximally inferred glycan string
   "Infers sequence ambiguities/uncertainties via biosynthetic invariances"
-  tax = df_species[df_species['Species'] == species].iloc[0, 2:9].to_dict()
+  if df_use is None:
+    df_use = copy.deepcopy(df_glycan[df_glycan.glycan_type == glycan_class])
+  tax = df_use[df_use[taxonomy_level].apply(lambda x: taxonomy_filter in str(x))].iloc[0].to_dict()
   if glycan.endswith("GlcNAc(b1-?)GlcNAc"):
     glycan = glycan.replace("GlcNAc(b1-?)GlcNAc", "GlcNAc(b1-4)GlcNAc")
-  if tax['Kingdom'] == 'Animalia':
+  if tax.get('Kingdom') == 'Animalia':
     glycan = glycan.replace("dHex", "Fuc")
     glycan = glycan.replace("Gal(b1-?)GlcNAc", "Gal(b1-3/4)GlcNAc")
   if "GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc" in glycan:
-    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if tax['Class'] == 'Mammalia' else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
+    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if tax.get('Class') == 'Mammalia' else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
   for old, new in [("Neu5Ac(a2-?)Neu5Ac", "Neu5Ac(a2-8)Neu5Ac"), ("Neu5Ac(a2-?)", "Neu5Ac(a2-3/6)"), ("Neu5Gc(a2-?)Neu5Gc", "Neu5Gc(a2-8)Neu5Gc"), ("Neu5Gc(a2-?)", "Neu5Gc(a2-3/6)"),
                    ("Fuc(a1-?)GlcNAc", "Fuc(a1-3/4)GlcNAc"), ("Fuc(a1-?)]GlcNAc", "Fuc(a1-3/4)]GlcNAc"), ("Fuc(a1-?)Gal(", "Fuc(a1-2)Gal("), ("GalOS", "Gal3/6S"), ("GlcNAcOS", "GlcNAc6S")]:
     glycan = glycan.replace(old, new)

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -1462,7 +1462,6 @@ def max_specify_glycan(glycan: str, # Glycan in IUPAC-condensed nomenclature
     glycan_class = get_class(glycan)
   if df_use is None:
     df_use = copy.deepcopy(df_glycan[df_glycan.glycan_type == glycan_class])
-  tax = df_use[df_use[taxonomy_level].apply(lambda x: isinstance(x, list) and taxonomy_filter in x)]
   if glycan.endswith("GlcNAc(b1-?)GlcNAc"):
     glycan = glycan.replace("GlcNAc(b1-?)GlcNAc", "GlcNAc(b1-4)GlcNAc")
   if taxonomy_level == "Kingdom" and taxonomy_filter == 'Animalia':

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -1450,12 +1450,15 @@ def is_composition(s: str # Either glycan or composition string
 
 
 def max_specify_glycan(glycan: str, # Glycan in IUPAC-condensed nomenclature
-                       glycan_class: str, # "O", "N", "lipid", "free"
+                       glycan_class: str = None, # "O", "N", "lipid", "free"
                        taxonomy_level: str = "Kingdom", # Which taxonomy level to filter by
                        taxonomy_filter: str = "Animalia", # Which taxonomy to pull glycans for
                        df_use: pd.DataFrame = None # Which sugarbase-like database of glycans with species associations etc.
                       ) -> str: # Maximally inferred glycan string
   "Infers sequence ambiguities/uncertainties via biosynthetic invariances"
+  if glycan_class is None:
+    from glycowork.motif.processing import get_class 
+    glycan_class = get_class(glycan)
   if df_use is None:
     df_use = copy.deepcopy(df_glycan[df_glycan.glycan_type == glycan_class])
   tax = df_use[df_use[taxonomy_level].apply(lambda x: taxonomy_filter in str(x))].iloc[0].to_dict()

--- a/glycowork/motif/processing.py
+++ b/glycowork/motif/processing.py
@@ -1457,18 +1457,17 @@ def max_specify_glycan(glycan: str, # Glycan in IUPAC-condensed nomenclature
                       ) -> str: # Maximally inferred glycan string
   "Infers sequence ambiguities/uncertainties via biosynthetic invariances"
   if glycan_class is None:
-    from glycowork.motif.processing import get_class 
     glycan_class = get_class(glycan)
   if df_use is None:
     df_use = copy.deepcopy(df_glycan[df_glycan.glycan_type == glycan_class])
-  tax = df_use[df_use[taxonomy_level].apply(lambda x: taxonomy_filter in str(x))].iloc[0].to_dict()
+  tax = df_use[df_use[taxonomy_level].apply(lambda x: isinstance(x, list) and taxonomy_filter in x)]
   if glycan.endswith("GlcNAc(b1-?)GlcNAc"):
     glycan = glycan.replace("GlcNAc(b1-?)GlcNAc", "GlcNAc(b1-4)GlcNAc")
-  if tax.get('Kingdom') == 'Animalia':
+  if taxonomy_level == "Kingdom" and taxonomy_filter == 'Animalia':
     glycan = glycan.replace("dHex", "Fuc")
     glycan = glycan.replace("Gal(b1-?)GlcNAc", "Gal(b1-3/4)GlcNAc")
   if "GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc" in glycan:
-    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if tax.get('Class') == 'Mammalia' else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
+    glycan = glycan.replace("GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc", "GlcNAc(b1-4)[Fuc(a1-6)]GlcNAc" if taxonomy_level == "Class" and taxonomy_filter == 'Mammalia' else "GlcNAc(b1-4)[Fuc(a1-3/6)]GlcNAc")
   for old, new in [("Neu5Ac(a2-?)Neu5Ac", "Neu5Ac(a2-8)Neu5Ac"), ("Neu5Ac(a2-?)", "Neu5Ac(a2-3/6)"), ("Neu5Gc(a2-?)Neu5Gc", "Neu5Gc(a2-8)Neu5Gc"), ("Neu5Gc(a2-?)", "Neu5Gc(a2-3/6)"),
                    ("Fuc(a1-?)GlcNAc", "Fuc(a1-3/4)GlcNAc"), ("Fuc(a1-?)]GlcNAc", "Fuc(a1-3/4)]GlcNAc"), ("Fuc(a1-?)Gal(", "Fuc(a1-2)Gal("), ("GalOS", "Gal3/6S"), ("GlcNAcOS", "GlcNAc6S")]:
     glycan = glycan.replace(old, new)


### PR DESCRIPTION
max_specify_glycan coverage() now accepts glycan_class, taxonomy_level, taxonomy_filter, and a sugarbase-like database of glycans to improve the annotation of the sequences.

# ⚠️ IMPORTANT: Branch Strategy

This repository follows a strict branch strategy:

- `master` branch is ONLY for PyPI release mirroring
- All development PRs MUST target the `dev` branch
- If your PR targets `master`, it will be flagged and you'll be asked to retarget to `dev`

---

## Description of Changes

...

## Changelog

- [ ] I have added my changes to CHANGELOG.md under the appropriate module/submodule section